### PR TITLE
Update static content security

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -39,6 +39,7 @@ admission:
 update_static_content:
  path: /updatestaticcontent
  defaults: {_controller: AppBundle:StaticContent:update }
+ methods: [POST]
 
 ##########################################
 #                Control Panel           #

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -76,6 +76,7 @@ security:
         - { path: ^/kontrollpanel/teamadmin/rediger/stilling, roles: ROLE_SUPER_ADMIN }
         - { path: ^/kontrollpanel/teamadmin/opprett/stilling, roles: ROLE_SUPER_ADMIN }
         - { path: ^/kontrollpanel/teamadmin/stilling/slett, roles: ROLE_SUPER_ADMIN }
+        - { path: ^/updatestaticcontent, roles: ROLE_SUPER_ADMIN }
 
           #ROLE_ADMIN = team user
         - { path: ^/profile/edit, roles: ROLE_ADMIN }


### PR DESCRIPTION
Lagt til /updatestaticcontent i security.yml med krav om å være super admin.
Kun godta POST fra /updatestaticcontent.