### PR TITLE
Allow application repository function to return null

### DIFF
--- a/src/AppBundle/Entity/Repository/ApplicationRepository.php
+++ b/src/AppBundle/Entity/Repository/ApplicationRepository.php
@@ -20,11 +20,11 @@ class ApplicationRepository extends EntityRepository
      * @param User     $user
      * @param Semester $semester
      *
-     * @return Application
+     * @return Application|null
      *
      * @throws \Doctrine\ORM\NonUniqueResultException
      */
-    public function findByUserInSemester(User $user, Semester $semester): Application
+    public function findByUserInSemester(User $user, Semester $semester)
     {
         return $this->createQueryBuilder('application')
             ->select('application')


### PR DESCRIPTION
I PHP 7.0 er ikke `null` en gyldig return type.
Vi kan begynne å bruke nullable return types når vi oppgraderer til versjon 7.1: http://php.net/manual/en/migration71.new-features.php