### PR TITLE
Use anonymousClient as default client in the goTo function

### DIFF
--- a/src/AppBundle/Tests/BaseWebTestCase.php
+++ b/src/AppBundle/Tests/BaseWebTestCase.php
@@ -71,8 +71,12 @@ abstract class BaseWebTestCase extends WebTestCase
         return self::$adminClient;
     }
 
-    protected function goTo(Client $client, string $path) : Crawler
+    protected function goTo(string $path, Client $client = null) : Crawler
     {
+        if ($client === null) {
+            $client = self::createAnonymousClient();
+        }
+
         $crawler = $client->request('GET', $path);
 
         $this->assertTrue($client->getResponse()->isSuccessful());
@@ -82,27 +86,27 @@ abstract class BaseWebTestCase extends WebTestCase
 
     protected function anonymousGoTo(string $path) : Crawler
     {
-        return $this->goTo(self::createAnonymousClient(), $path);
+        return $this->goTo($path, self::createAnonymousClient());
     }
 
     protected function assistantGoTo(string $path) : Crawler
     {
-        return $this->goTo(self::createAssistantClient(), $path);
+        return $this->goTo($path, self::createAssistantClient());
     }
 
     protected function teamMemberGoTo(string $path) : Crawler
     {
-        return $this->goTo(self::createTeamMemberClient(), $path);
+        return $this->goTo($path, self::createTeamMemberClient());
     }
 
     protected function teamLeaderGoTo(string $path) : Crawler
     {
-        return $this->goTo(self::createTeamLeaderClient(), $path);
+        return $this->goTo($path, self::createTeamLeaderClient());
     }
 
     protected function adminGoTo(string $path) : Crawler
     {
-        return $this->goTo(self::createAdminClient(), $path);
+        return $this->goTo($path, self::createAdminClient());
     }
 
     protected function countTableRows(string $path, Client $client = null) : int
@@ -111,7 +115,7 @@ abstract class BaseWebTestCase extends WebTestCase
             $client = self::createAdminClient();
         }
 
-        $crawler = $this->goTo($client, $path);
+        $crawler = $this->goTo($path, $client);
 
         return $crawler->filter('tr')->count();
     }

--- a/src/AppBundle/Tests/Controller/AboutVektorControllerTest.php
+++ b/src/AppBundle/Tests/Controller/AboutVektorControllerTest.php
@@ -8,7 +8,7 @@ class AboutVektorControllerTest extends BaseWebTestCase
 {
     public function testShow()
     {
-        $crawler = $this->anonymousGoTo('/omvektor');
+        $crawler = $this->goTo('/omvektor');
 
         $this->assertEquals(1, $crawler->filter('h1:contains("Om Vektorprogrammet")')->count());
         $this->assertEquals(1, $crawler->filter('h1:contains("Mål og verdier")')->count());
@@ -21,7 +21,7 @@ class AboutVektorControllerTest extends BaseWebTestCase
 
     public function testShowFaq()
     {
-        $crawler = $this->anonymousGoTo('/faq');
+        $crawler = $this->goTo('/faq');
 
         $this->assertEquals(1, $crawler->filter('h1:contains("Ofte stilte spørsmål")')->count());
     }


### PR DESCRIPTION
I tester er det vanlig å opprette en `Client` og gå til en path:
```php
$client = static::createClient();
 
$crawler = $client->request('GET', '/omvektor');
$this->assertTrue($client->getResponse()->isSuccessful());
```
I tester som extender `BaseWebTestCase` kan dette kan nå skrives som:
(Nytt i denne PRen)
```php
$crawler = $this->goTo('/omvektor'); // Ikke-innlogget client
```
Dette er ekvivalent med:
(Eksisterer fra før)
```php
$crawler = $this->anonymousGoTo('/omvektor'); // Ikke-innlogget client
```
Klienter med andre rettigheter:
(Eksisterer fra før)
```php
$crawler = $this->assistantGoTo('/omvektor');  // ROLE_USER
$crawler = $this->teamMemberGoTo('/omvektor'); // ROLE_ADMIN
$crawler = $this->teamLeaderGoTo('/omvektor'); // ROLE_SUPER_ADMIN
$crawler = $this->adminGoTo('/omvektor');      // ROLE_HIGHEST_ADMIN
```