### PR TITLE
Teamleaders should not be able to change the role of admins.

### DIFF
--- a/app/Resources/views/profile/public_profile.html.twig
+++ b/app/Resources/views/profile/public_profile.html.twig
@@ -50,21 +50,22 @@
                                 bilde</a></li>
                         <li role="menuitem"><a href="{{ path('profile_certificate', { id: user.id} ) }}">Last
                                 ned attest</a></li>
+                        {% if not user_is_granted_admin(user) %}
+                            <li role="menuitem">
+                                <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false">Rediger
+                                    rettighetsnivå</a>
+                                <ul id="drop1" class="f-dropdown" data-dropdown-content aria-hidden="true"
+                                    tabindex="-1">
 
-                        <li role="menuitem">
-                            <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false">Rediger
-                                rettighetsnivå</a>
-                            <ul id="drop1" class="f-dropdown" data-dropdown-content aria-hidden="true"
-                                tabindex="-1">
-
-                                <li><a href="#" name={{ user.id }} class="assistent"
-                                       id="assistant"> Assistent </a></li>
-                                <li><a href="#" name={{ user.id }} class="team"
-                                       id="team_member"> Teammedlem </a></li>
-                                <li><a href="#" name={{ user.id }} class="admin"
-                                       id="team_leader"> Teamleder </a></li>
-                            </ul>
-                        </li>
+                                    <li><a href="#" name={{ user.id }} class="assistent"
+                                           id="assistant"> Assistent </a></li>
+                                    <li><a href="#" name={{ user.id }} class="team"
+                                           id="team_member"> Teammedlem </a></li>
+                                    <li><a href="#" name={{ user.id }} class="admin"
+                                           id="team_leader"> Teamleder </a></li>
+                                </ul>
+                            </li>
+                        {% endif %}
 
                         <li role="menuitem">
                             <a data-dropdown="drop2" aria-controls="drop2" aria-expanded="false">Rediger

--- a/src/AppBundle/Controller/ProfileController.php
+++ b/src/AppBundle/Controller/ProfileController.php
@@ -139,7 +139,7 @@ class ProfileController extends Controller
         $roleManager = $this->get('app.roles');
         $roleName = $roleManager->mapAliasToRole($request->request->get('role'));
 
-        if (!$roleManager->canChangeToRole($roleName)) {
+        if (!$roleManager->loggedInUserCanChangeRoleOfUsersWithRole($user, $roleName)) {
             throw new BadRequestHttpException();
         }
 

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -66,7 +66,7 @@ services:
 
   app.role_extension:
     class: AppBundle\Twig\Extension\RoleExtension
-    arguments: ['@security.authorization_checker', '@security.token_storage']
+    arguments: ['@security.authorization_checker', '@security.token_storage', '@app.roles']
     tags:
         - { name: twig.extension }
 

--- a/src/AppBundle/Service/RoleManager.php
+++ b/src/AppBundle/Service/RoleManager.php
@@ -92,19 +92,22 @@ class RoleManager
 
     public function userIsGranted(User $user, string $role): bool
     {
+        $roles = array(
+            Roles::ASSISTANT,
+            Roles::TEAM_MEMBER,
+            Roles::TEAM_LEADER,
+            Roles::ADMIN,
+        );
+
         if (empty($user->getRoles())) {
             return false;
         }
 
-        $roles = array(
-            'ROLE_USER',
-            'ROLE_ADMIN',
-            'ROLE_SUPER_ADMIN',
-            'ROLE_HIGHEST_ADMIN',
-        );
-
         $userRole = $user->getRoles()[0]->getRole();
 
-        return array_search($userRole, $roles) >= array_search($role, $roles);
+        $userAccessLevel = array_search($userRole, $roles);
+        $roleAccessLevel = array_search($role, $roles);
+
+        return $userAccessLevel >= $roleAccessLevel;
     }
 }

--- a/src/AppBundle/Service/RoleManager.php
+++ b/src/AppBundle/Service/RoleManager.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Service;
 
 use AppBundle\Entity\User;
-use AppBundle\Entity\Role;
 use AppBundle\Role\Roles;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 

--- a/src/AppBundle/Twig/Extension/RoleExtension.php
+++ b/src/AppBundle/Twig/Extension/RoleExtension.php
@@ -2,7 +2,9 @@
 
 namespace AppBundle\Twig\Extension;
 
+use AppBundle\Entity\User;
 use AppBundle\Role\Roles;
+use AppBundle\Service\RoleManager;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 
@@ -10,11 +12,16 @@ class RoleExtension extends \Twig_Extension
 {
     private $authorizationChecker;
     private $tokenStorage;
+    /**
+     * @var RoleManager
+     */
+    private $roleManager;
 
-    public function __construct(AuthorizationChecker $authorizationChecker, TokenStorage $tokenStorage)
+    public function __construct(AuthorizationChecker $authorizationChecker, TokenStorage $tokenStorage, RoleManager $roleManager)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
+        $this->roleManager = $roleManager;
     }
 
     public function getName()
@@ -29,6 +36,10 @@ class RoleExtension extends \Twig_Extension
             'is_granted_team_member' => new \Twig_Function_Method($this, 'isGrantedTeamMember'),
             'is_granted_team_leader' => new \Twig_Function_Method($this, 'isGrantedTeamLeader'),
             'is_granted_admin' => new \Twig_Function_Method($this, 'isGrantedAdmin'),
+            'user_is_granted_assistant' => new \Twig_Function_Method($this, 'userIsGrantedAssistant'),
+            'user_is_granted_team_member' => new \Twig_Function_Method($this, 'userIsGrantedTeamMember'),
+            'user_is_granted_team_leader' => new \Twig_Function_Method($this, 'userIsGrantedTeamLeader'),
+            'user_is_granted_admin' => new \Twig_Function_Method($this, 'userIsGrantedAdmin'),
         );
     }
 
@@ -59,5 +70,25 @@ class RoleExtension extends \Twig_Extension
         }
 
         return $this->authorizationChecker->isGranted($role);
+    }
+
+    public function userIsGrantedAssistant(User $user)
+    {
+        return $this->roleManager->userIsGranted($user, Roles::ASSISTANT);
+    }
+
+    public function userIsGrantedTeamMember(User $user)
+    {
+        return $this->roleManager->userIsGranted($user, Roles::TEAM_MEMBER);
+    }
+
+    public function userIsGrantedTeamLeader(User $user)
+    {
+        return $this->roleManager->userIsGranted($user, Roles::TEAM_LEADER);
+    }
+
+    public function userIsGrantedAdmin(User $user)
+    {
+        return $this->roleManager->userIsGranted($user, Roles::ADMIN);
     }
 }


### PR DESCRIPTION
Issue #461 

Tidligere kunne teamleaders endre rettighetsnivået til admins fra profilsiden. Dette er nå fikset, både i twig og i controlleren. 

Det er også lagt til en `userIsGranted` funksjon til `RoleManager.php` som tar inn en bruker og en rolle. Tilhørende twig-funksjoner er også lagt til i `RoleExtension.php`