### PR TITLE
Add version to all assets to bust browser cache when asset is updated

### DIFF
--- a/app/Resources/views/admission/index.html.twig
+++ b/app/Resources/views/admission/index.html.twig
@@ -190,7 +190,7 @@
 
                 <div class="small-12 medium-12 large-6 columns">
 
-                    {#<img src="{{ asset("img/temp/greybox2.png") }}"/>#}
+                    {#<img src="{{ asset_with_version("img/temp/greybox2.png") }}"/>#}
 
                 </div>
 
@@ -219,7 +219,7 @@
 
                 <div class="small-12 medium-12 large-6 columns">
 
-                    {#<img src="{{ asset("img/temp/greybox2.png") }}"/>#}
+                    {#<img src="{{ asset_with_version("img/temp/greybox2.png") }}"/>#}
 
                 </div>
 

--- a/app/Resources/views/admission_admin/layout.html.twig
+++ b/app/Resources/views/admission_admin/layout.html.twig
@@ -2,10 +2,10 @@
 
 {% block javascripts %}
 
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
-    <script src="{{ asset('js/stupidtable.js') }}"></script>
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/stupidtable.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/article/carousel.html.twig
+++ b/app/Resources/views/article/carousel.html.twig
@@ -2,7 +2,7 @@
     <div class="small-12 medium-8 medium-push-4 columns">
         <div class="news-carousel">
             {% for article in articles %}
-                <div><img src="{{ asset(article.imageMedium) }}"/></div>
+                <div><img src="{{ asset_with_version(article.imageMedium) }}"/></div>
             {% else %}
                 <div><h3>Ingen nyheter</h3></div>
             {% endfor %}

--- a/app/Resources/views/article/department_news.html.twig
+++ b/app/Resources/views/article/department_news.html.twig
@@ -1,7 +1,7 @@
 {% for article in articles %}
     <div class="small-12 medium-3 large-3 columns">
         <a href="{{ path('article_show', { 'id': article.id }) }}">
-            <img src="{{ asset(article.imageSmall) }}">
+            <img src="{{ asset_with_version(article.imageSmall) }}">
         </a>
         <a href="{{ path('article_show', { 'id': article.id }) }}">{{ article.title|safe_html }}</a>
     </div>

--- a/app/Resources/views/article/index.html.twig
+++ b/app/Resources/views/article/index.html.twig
@@ -3,8 +3,8 @@
 {% block title %}Nyheter{% endblock %}
 
 {% block javascripts %}
-    <script src="{{ asset('vendor/ckeditor/ckeditor.js') }}"></script>
-    <script src="{{ asset('vendor/ckeditor/adapters/jquery.js') }}"></script>
+    <script src="{{ asset_with_version('vendor/ckeditor/ckeditor.js') }}"></script>
+    <script src="{{ asset_with_version('vendor/ckeditor/adapters/jquery.js') }}"></script>
     {% include "statictext/js_loader_for_static_texts.html.twig" %}
 {% endblock %}
 
@@ -17,7 +17,7 @@
                 <div class="row">
                     <div class="article-box small-12 medium-12 large-12 columns">
                         <a href="{{ path('article_show', { 'id': pagination|first.id }) }}">
-                            <img src="{{ asset(pagination|first.imageLarge) }}"/>
+                            <img src="{{ asset_with_version(pagination|first.imageLarge) }}"/>
                         </a>
                         <h4><a href="{{ path('article_show', { 'id': pagination|first.id }) }}">
                                 {{ pagination|first.title|safe_html }}</a></h4>
@@ -30,9 +30,9 @@
                             {% set images = [column.imageMedium, column.imageSmall] %}
                             <div class="article-box small-12 {{ cycle(columns, loop.parent.loop.index0+loop.index0) }} columns">
                                 <a href="{{ path('article_show', { 'id': column.id }) }}">
-                                    <img data-interchange="[{{ asset(column.imageMedium) }}, (default)], [{{ asset(cycle(images, loop.parent.loop.index0+loop.index0)) }}, (medium)]">
+                                    <img data-interchange="[{{ asset_with_version(column.imageMedium) }}, (default)], [{{ asset_with_version(cycle(images, loop.parent.loop.index0+loop.index0)) }}, (medium)]">
                                     <noscript><img
-                                                src="{{ asset(cycle(images, loop.parent.loop.index0+loop.index0)) }}">
+                                                src="{{ asset_with_version(cycle(images, loop.parent.loop.index0+loop.index0)) }}">
                                     </noscript>
                                 </a>
                                 <h5><a href="{{ path('article_show', { 'id': column.id }) }}">

--- a/app/Resources/views/article/show.html.twig
+++ b/app/Resources/views/article/show.html.twig
@@ -21,7 +21,7 @@
     <article>
         <div class="row">
             <div class="small-12 medium-12 large-12 columns">
-                <img src="{{ asset(article.imageLarge) }}" style="width:100%;"/>
+                <img src="{{ asset_with_version(article.imageLarge) }}" style="width:100%;"/>
             </div>
         </div>
         <div class="row">

--- a/app/Resources/views/article_admin/form.html.twig
+++ b/app/Resources/views/article_admin/form.html.twig
@@ -2,9 +2,9 @@
 
 {% block javascripts %}
     {{ parent() }}
-    <script src="{{ asset('js/optionbox.js') }}"></script>
+    <script src="{{ asset_with_version('js/optionbox.js') }}"></script>
     <!-- Load Aviary widget code -->
-    <script type="text/javascript" src="{{ asset('js/aviaryImageEditor.js') }}"></script>
+    <script type="text/javascript" src="{{ asset_with_version('js/aviaryImageEditor.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/article_admin/index.html.twig
+++ b/app/Resources/views/article_admin/index.html.twig
@@ -1,9 +1,9 @@
 {% extends 'adminBase.html.twig' %}
 
 {% block javascripts %}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -16,7 +16,7 @@
     {% endif %}
     <meta property="og:title" content="{{ block('title') }}"/>
     <meta property="og:image"
-          content="http://vektorprogrammet.no{% block facebookImage %}{{ asset('images/vektor_stor.png') }}{% endblock %}"/>
+          content="http://vektorprogrammet.no{% block facebookImage %}{{ asset_with_version('images/vektor_stor.png') }}{% endblock %}"/>
     <meta property="og:description"
           content="{% block facebookDescription %}Vektorprogrammet er Norges største organisasjon som jobber for å øke interessen for matematikk og realfag blant elever i grunnskolen. Vi sender realfagssterke studenter til barne- og ungdomsskoler hvor de fungerer som lærerens assistent.{% endblock %}"/>
     <meta property="og:site_name" content="Vektorprogrammet"/>
@@ -26,8 +26,8 @@
     <meta name="msapplication-navbutton-color" content="#6FCEEE"><!-- Windows Phone -->
     <meta name="apple-mobile-web-app-status-bar-style" content="#6FCEEE"><!-- iOS Safari -->
 
-    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
-    <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}?v=2"/>
+    <link rel="stylesheet" href="{{ asset_with_version('css/app.css') }}">
+    <link rel="icon" type="image/x-icon" href="{{ asset_with_version('favicon.ico') }}"/>
     {% block stylesheets %}{% endblock %}
 
     {% block customStyles %}{% endblock %}
@@ -55,7 +55,7 @@
     {% include 'base/footer.html.twig' %}
 {% endblock %}
 
-<script src="{{ asset('js/vendor.js') }}"></script>
+<script src="{{ asset_with_version('js/vendor.js') }}"></script>
 <script>
     {# This has to be in all twig files, can't be overwritten #}
     $(document).foundation();

--- a/app/Resources/views/base/logo_link.html.twig
+++ b/app/Resources/views/base/logo_link.html.twig
@@ -1,7 +1,7 @@
 <a href="{{ path('home') }}">
     {% if "now"|date("m") == "12" %}
-        <img src="{{ asset('images/vektor-christmas-logo.png') }}" alt="Vektor logo">
+        <img src="{{ asset_with_version('images/vektor-christmas-logo.png') }}" alt="Vektor logo">
     {% else %}
-        <img src="{{ asset('images/vektor.png') }}" alt="Vektor logo">
+        <img src="{{ asset_with_version('images/vektor.png') }}" alt="Vektor logo">
     {% endif %}
 </a>

--- a/app/Resources/views/certificate/certificate.html.twig
+++ b/app/Resources/views/certificate/certificate.html.twig
@@ -8629,7 +8629,7 @@
             <hr>
             <br>
             <div class="row">
-                <img src="{{ base_dir ~ asset_with_version('images/vektor.png') }}" alt=""
+                <img src="{{ base_dir ~ asset('images/vektor.png') }}" alt=""
                      style="float:right; margin-left: 20px; margin-top: -8px">
                 <div class="address" style="text-align: left; font-size: 14px; margin-left: 14px;">
 

--- a/app/Resources/views/certificate/certificate.html.twig
+++ b/app/Resources/views/certificate/certificate.html.twig
@@ -8629,7 +8629,7 @@
             <hr>
             <br>
             <div class="row">
-                <img src="{{ base_dir ~ asset('images/vektor.png') }}" alt=""
+                <img src="{{ base_dir ~ asset_with_version('images/vektor.png') }}" alt=""
                      style="float:right; margin-left: 20px; margin-top: -8px">
                 <div class="address" style="text-align: left; font-size: 14px; margin-left: 14px;">
 

--- a/app/Resources/views/certificate/certificate_download.html.twig
+++ b/app/Resources/views/certificate/certificate_download.html.twig
@@ -2,10 +2,10 @@
 
 {% block customScripts %}
 
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
-    <script src="{{ asset('js/stupidtable.js') }}"></script>
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/stupidtable.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/certificate/signature_picture_upload.html.twig
+++ b/app/Resources/views/certificate/signature_picture_upload.html.twig
@@ -31,7 +31,7 @@
                 </div>
                 <div class="small-4 columns">
                     <div class="{{ signature.signaturePath is not null ? '' : 'hide' }}">
-                        <img src="{{ asset(signature.signaturePath) }}" height="60px" id="signature_picture">
+                        <img src="{{ asset_with_version(signature.signaturePath) }}" height="60px" id="signature_picture">
                     </div>
                 </div>
             </div>

--- a/app/Resources/views/department_admin/index.html.twig
+++ b/app/Resources/views/department_admin/index.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/file_system/public_files.html.twig
+++ b/app/Resources/views/file_system/public_files.html.twig
@@ -6,7 +6,7 @@
             {% for file in files %}
                 {% set splut_string = file|split('/') %}
                 <li>
-                    <a href="{{ asset(file) }}">{{ splut_string[splut_string|length-1] }}</a>
+                    <a href="{{ asset_with_version(file) }}">{{ splut_string[splut_string|length-1] }}</a>
                 </li>
             {% endfor %}
         </ul>

--- a/app/Resources/views/home/index.html.twig
+++ b/app/Resources/views/home/index.html.twig
@@ -6,13 +6,13 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" type="text/css" href="{{ asset('vendor/slick/slick.css') }}"/>
-    <link rel="stylesheet" type="text/css" href="{{ asset('vendor/slick/slick-theme.css') }}"/>
+    <link rel="stylesheet" type="text/css" href="{{ asset_with_version('vendor/slick/slick.css') }}"/>
+    <link rel="stylesheet" type="text/css" href="{{ asset_with_version('vendor/slick/slick-theme.css') }}"/>
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
-    <script type="text/javascript" src="{{ asset('vendor/slick/slick.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset_with_version('vendor/slick/slick.min.js') }}"></script>
     {% include "statictext/js_loader_for_static_texts.html.twig" %}
     <script>
         $(document).ready(function () {

--- a/app/Resources/views/interview/schemas.html.twig
+++ b/app/Resources/views/interview/schemas.html.twig
@@ -6,9 +6,9 @@
 
 {% block javascripts %}
 
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/newsletter/mail_template.html.twig
+++ b/app/Resources/views/newsletter/mail_template.html.twig
@@ -6,6 +6,6 @@
 <br>
 <p>Hilsen Vektorprogrammet, {{ department }}</p>
 
-<img src="{{ app.request.getSchemeAndHttpHost() ~ asset('images/vektor.png') }}">
+<img src="{{ app.request.getSchemeAndHttpHost() ~ asset_with_version('images/vektor.png') }}">
 <br>
 <i>Hvis du ikke ønsker å motta flere nyhetsbrev kan du klikke <a href="{{ app.request.getSchemeAndHttpHost() ~ path('unsubscribe_newsletter', {'unsubscribeCode':unsubscribeCode}) }}">her</a> for å melde deg av.</i>

--- a/app/Resources/views/newsletter/subscribe.html.twig
+++ b/app/Resources/views/newsletter/subscribe.html.twig
@@ -4,12 +4,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ newsletter.name }}, Vektorprogrammet</title>
 
-    <link rel="stylesheet" rel="stylesheet" type="text/css" href="{{ asset('css/app.css') }}">
+    <link rel="stylesheet" rel="stylesheet" type="text/css" href="{{ asset_with_version('css/app.css') }}">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}?v=2"/>
+    <link rel="icon" type="image/x-icon" href="{{ asset_with_version('favicon.ico') }}?v=2"/>
 
     {# Used by Foundation for backwards compability, and is supposed to be in the header #}
-    <script src="{{ asset('js/vendor/modernizr.js') }}"></script>
+    <script src="{{ asset_with_version('js/vendor/modernizr.js') }}"></script>
 
     <style>
         body {
@@ -71,7 +71,7 @@
     <div class="content">
         <div class="row">
             <div class="small-12 columns">
-                <img src="{{ asset('images/vektor.png') }}" alt="Vektor logo">
+                <img src="{{ asset_with_version('images/vektor.png') }}" alt="Vektor logo">
             </div>
         </div>
         <div class="row">

--- a/app/Resources/views/profile/download_certificate.pdf.twig
+++ b/app/Resources/views/profile/download_certificate.pdf.twig
@@ -1,4 +1,4 @@
-<link rel="stylesheet type=" text/css" href="{{ asset(css/app.css) }}">
+<link rel="stylesheet type=" text/css" href="{{ asset_with_version(css/app.css) }}">
 
 {% block body %}
 

--- a/app/Resources/views/profile/edit_profile_photo.html.twig
+++ b/app/Resources/views/profile/edit_profile_photo.html.twig
@@ -6,8 +6,8 @@
 
 {% block javascripts %}
 
-    <script type="text/javascript" src="{{ asset('vendor/dropzone/dist/min/dropzone.min.js') }}"></script>
-    <script type="text/javascript" src="{{ asset('js/aviaryImageEditor.js') }}"></script>
+    <script type="text/javascript" src="{{ asset_with_version('vendor/dropzone/dist/min/dropzone.min.js') }}"></script>
+    <script type="text/javascript" src="{{ asset_with_version('js/aviaryImageEditor.js') }}"></script>
 
     <script>
 
@@ -223,7 +223,7 @@
                         </div>
                         <div class="medium-6 columns text-center bordered">
 
-                            <img id="profileImg" src="{{ path }}"/>
+                            <img id="profileImg" src="{{ asset_with_version(path) }}"/>
                             <div class="row">
                                 <br>
                                 <a href="#" class="button small" id="editImageBtn">Rediger bilde</a>

--- a/app/Resources/views/profile/profile.html.twig
+++ b/app/Resources/views/profile/profile.html.twig
@@ -8,10 +8,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/genericAjax.js') }}"></script>
+    <script src="{{ asset_with_version('js/genericAjax.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/profile/profile_picture.html.twig
+++ b/app/Resources/views/profile/profile_picture.html.twig
@@ -1,4 +1,4 @@
-<img src="{{ asset(user.picturePath) }}"/>
+<img src="{{ asset_with_version(user.picturePath) }}"/>
 <div class="panel callout radius">
     <h3>
         {{ user.firstName }} {{ user.lastName }}

--- a/app/Resources/views/profile/public_profile.html.twig
+++ b/app/Resources/views/profile/public_profile.html.twig
@@ -3,11 +3,11 @@
 {% block javascripts %}
 
     {# Need these to expose the routes to our JS code #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
 
     {# import the genericAjax.js file #}
-    <script src="{{ asset('js/genericAjax.js') }}"></script>
+    <script src="{{ asset_with_version('js/genericAjax.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/school_admin/index.html.twig
+++ b/app/Resources/views/school_admin/index.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/school_admin/specific_school.html.twig
+++ b/app/Resources/views/school_admin/specific_school.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/semester_admin/index.html.twig
+++ b/app/Resources/views/semester_admin/index.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/sponsors/sponsors.html.twig
+++ b/app/Resources/views/sponsors/sponsors.html.twig
@@ -9,7 +9,7 @@
             <div class="small-12 medium-6 large-6 sponsor-column {{ loop.last? 'end':'' }} {% if (((large_sponsors|length) % 2) == 1) and loop.last %}medium-offset-3{% endif %} columns">
                 <a href="{{ sponsor.url }}">
                     <span class="vertical-align-image-helper"></span><img class="sponsor-img-large"
-                                                                          src="{{ asset(sponsor.logoImagePath) }}">
+                                                                          src="{{ asset_with_version(sponsor.logoImagePath) }}">
                 </a>
             </div>
         {% endfor %}
@@ -28,7 +28,7 @@
         {% endif %} columns">
             <a href="{{ sponsor.url }}">
                 <span class="vertical-align-image-helper"></span><img class="sponsor-img-{{ sponsor.size }}"
-                                                                      src="{{ asset(sponsor.logoImagePath) }}">
+                                                                      src="{{ asset_with_version(sponsor.logoImagePath) }}">
             </a>
         </div>
     {% endfor %}
@@ -43,7 +43,7 @@
         {% endif %} columns">
             <a href="{{ sponsor.url }}">
                 <span class="vertical-align-image-helper"></span><img class="sponsor-img-{{ sponsor.size }}"
-                                                                      src="{{ asset(sponsor.logoImagePath) }}">
+                                                                      src="{{ asset_with_version(sponsor.logoImagePath) }}">
             </a>
         </div>
     {% endfor %}

--- a/app/Resources/views/sponsors/sponsors_edit.html.twig
+++ b/app/Resources/views/sponsors/sponsors_edit.html.twig
@@ -16,7 +16,7 @@
             </td>
             <td>
                 Nåværende logo:<br>
-                <img src="{{ asset(logos[loop.index0] ) }}" height="60px">
+                <img src="{{ asset_with_version(logos[loop.index0] ) }}" height="60px">
             </td>
         </tr>
     {% endfor %}
@@ -65,7 +65,7 @@
                     Nåværende logo
                 </div>
                 <div class="row">
-                    <img src="{{ asset(logos[loop.index0] ) }}" height="60px">
+                    <img src="{{ asset_with_version(logos[loop.index0] ) }}" height="60px">
                 </div>
                 <div class="row">
                     {{ form_widget(form.logoImagePath, {'attr': {'value': 'Last opp ny logo'}}) }}

--- a/app/Resources/views/statictext/js_loader_for_static_texts.html.twig
+++ b/app/Resources/views/statictext/js_loader_for_static_texts.html.twig
@@ -7,9 +7,9 @@
 
 {% if is_granted_team_leader() %}
     <script> var dump_file = "{{ path('update_static_content') }}" </script>
-    <script src="{{ asset('vendor/ckeditor/ckeditor.js') }}"></script>
-    <script src="{{ asset('vendor/ckeditor/adapters/jquery.js') }}"></script>
-    <script src="{{ asset('js/ckeditor/createCkeditorInstances.js') }}"></script>
+    <script src="{{ asset_with_version('vendor/ckeditor/ckeditor.js') }}"></script>
+    <script src="{{ asset_with_version('vendor/ckeditor/adapters/jquery.js') }}"></script>
+    <script src="{{ asset_with_version('js/ckeditor/createCkeditorInstances.js') }}"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             createCkeditorInstances();

--- a/app/Resources/views/substitute/index.html.twig
+++ b/app/Resources/views/substitute/index.html.twig
@@ -2,7 +2,7 @@
 
 {% block javascripts %}
 
-    <script src="{{ asset('js/stupidtable.js') }}"></script>
+    <script src="{{ asset_with_version('js/stupidtable.js') }}"></script>
     <script>
         var Substitute = {
             // The html table containing the substitute assistants

--- a/app/Resources/views/survey/surveys.html.twig
+++ b/app/Resources/views/survey/surveys.html.twig
@@ -6,9 +6,9 @@
 
 {% block javascripts %}
 
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/survey/takeSurvey.html.twig
+++ b/app/Resources/views/survey/takeSurvey.html.twig
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>Spørreundersøkelse Vektorprogrammet</title>
 
-    <link rel="stylesheet" rel="stylesheet" type="text/css" href="{{ asset('css/survey.css') }}">
+    <link rel="stylesheet" rel="stylesheet" type="text/css" href="{{ asset_with_version('css/survey.css') }}">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}?v=2"/>
+    <link rel="icon" type="image/x-icon" href="{{ asset_with_version('favicon.ico') }}?v=2"/>
 
     {# Used by Foundation for backwards compability, and is supposed to be in the header #}
 
@@ -30,7 +30,7 @@
     {% form_theme form 'form/surv_layout.html.twig' %}
 
 
-    <img src="{{ asset('images/vektor.png') }}" alt="Vektor logo">
+    <img src="{{ asset_with_version('images/vektor.png') }}" alt="Vektor logo">
     <br/>
     <h1>{{ form.vars.data.survey.name }}</h1>
     <h5>{{ form.vars.data.survey.semester }}</h5>

--- a/app/Resources/views/team/team_page.html.twig
+++ b/app/Resources/views/team/team_page.html.twig
@@ -45,7 +45,7 @@
 
                     <tr>
                         <td width="100">
-                            <img width="50" src="{{ asset(wh.user.picturePath) }}"/>
+                            <img width="50" src="{{ asset_with_version(wh.user.picturePath) }}"/>
                         </td>
                         <td>
                             {% if app.user %}

--- a/app/Resources/views/team_admin/index.html.twig
+++ b/app/Resources/views/team_admin/index.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/team_admin/show_positions.html.twig
+++ b/app/Resources/views/team_admin/show_positions.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/app/Resources/views/team_admin/specific_team.html.twig
+++ b/app/Resources/views/team_admin/specific_team.html.twig
@@ -3,10 +3,10 @@
 {% block javascripts %}
 
     {# Easy routing with FOSJsRouting bundle #}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ asset_with_version('bundles/fosjsrouting/js/router.js') }}"></script>
     <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
     {# We need the deletetablerow.js file #}
-    <script src="{{ asset('js/deleteablerow.js') }}"></script>
+    <script src="{{ asset_with_version('js/deleteablerow.js') }}"></script>
 
     <script>
 

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -142,4 +142,9 @@ services:
     tags:
       - { name: twig.extension }
 
-
+  app.twig.extension.assets:
+        class: AppBundle\Twig\Extension\AssetExtension
+        arguments: ['@assets.packages', '%kernel.root_dir%']
+        public: false
+        tags:
+          - { name: twig.extension }

--- a/src/AppBundle/Twig/Extension/AssetExtension.php
+++ b/src/AppBundle/Twig/Extension/AssetExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AppBundle\Twig\Extension;
+
+use Symfony\Component\Asset\Packages;
+
+class AssetExtension extends \Twig_Extension {
+	private $packages;
+	private $rootDir;
+
+	/**
+	 * AssetExtension constructor.
+	 *
+	 * @param Packages $packages
+	 * @param string $rootDir
+	 */
+	public function __construct( Packages $packages, string $rootDir ) {
+		$this->packages = $packages;
+		$this->rootDir  = $rootDir;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFunctions() {
+		return array(
+			new \Twig_SimpleFunction( 'asset_with_version', array( $this, 'getAssetUrl' ) ),
+		);
+	}
+
+	/**
+	 * Returns the public url/path of an asset.
+	 *
+	 * If the package used to generate the path is an instance of
+	 * UrlPackage, you will always get a URL and not a path.
+	 *
+	 * @param string $path A public path
+	 * @param string $packageName The name of the asset package to use
+	 *
+	 * @return string The public path of the asset
+	 */
+	public function getAssetUrl( $path, $packageName = null ) {
+		if (strlen($path) === 0) {
+			return $path;
+		}
+
+		if ( $path[0] !== '/' ) {
+			$path = "/$path";
+		}
+		$filePath = $this->rootDir . "/../www$path";
+
+		$version = "";
+		if ( file_exists( $filePath ) ) {
+			$version = filemtime( $filePath );
+		}
+
+		$url = $this->packages->getUrl( $path, $packageName );
+		if ( strlen( $version ) > 0 ) {
+			$url .= "?v=" . $version;
+		}
+
+		return $url;
+	}
+}

--- a/src/AppBundle/Twig/Extension/AssetExtension.php
+++ b/src/AppBundle/Twig/Extension/AssetExtension.php
@@ -4,61 +4,65 @@ namespace AppBundle\Twig\Extension;
 
 use Symfony\Component\Asset\Packages;
 
-class AssetExtension extends \Twig_Extension {
-	private $packages;
-	private $rootDir;
+class AssetExtension extends \Twig_Extension
+{
+    private $packages;
+    private $rootDir;
 
-	/**
-	 * AssetExtension constructor.
-	 *
-	 * @param Packages $packages
-	 * @param string $rootDir
-	 */
-	public function __construct( Packages $packages, string $rootDir ) {
-		$this->packages = $packages;
-		$this->rootDir  = $rootDir;
-	}
+    /**
+     * AssetExtension constructor.
+     *
+     * @param Packages $packages
+     * @param string   $rootDir
+     */
+    public function __construct(Packages $packages, string $rootDir)
+    {
+        $this->packages = $packages;
+        $this->rootDir = $rootDir;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getFunctions() {
-		return array(
-			new \Twig_SimpleFunction( 'asset_with_version', array( $this, 'getAssetUrl' ) ),
-		);
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('asset_with_version', array($this, 'getAssetUrl')),
+        );
+    }
 
-	/**
-	 * Returns the public url/path of an asset.
-	 *
-	 * If the package used to generate the path is an instance of
-	 * UrlPackage, you will always get a URL and not a path.
-	 *
-	 * @param string $path A public path
-	 * @param string $packageName The name of the asset package to use
-	 *
-	 * @return string The public path of the asset
-	 */
-	public function getAssetUrl( $path, $packageName = null ) {
-		if (strlen($path) === 0) {
-			return $path;
-		}
+    /**
+     * Returns the public url/path of an asset.
+     *
+     * If the package used to generate the path is an instance of
+     * UrlPackage, you will always get a URL and not a path.
+     *
+     * @param string $path        A public path
+     * @param string $packageName The name of the asset package to use
+     *
+     * @return string The public path of the asset
+     */
+    public function getAssetUrl($path, $packageName = null)
+    {
+        if (strlen($path) === 0) {
+            return $path;
+        }
 
-		if ( $path[0] !== '/' ) {
-			$path = "/$path";
-		}
-		$filePath = $this->rootDir . "/../www$path";
+        if ($path[0] !== '/') {
+            $path = "/$path";
+        }
+        $filePath = $this->rootDir."/../www$path";
 
-		$version = "";
-		if ( file_exists( $filePath ) ) {
-			$version = filemtime( $filePath );
-		}
+        $version = '';
+        if (file_exists($filePath)) {
+            $version = filemtime($filePath);
+        }
 
-		$url = $this->packages->getUrl( $path, $packageName );
-		if ( strlen( $version ) > 0 ) {
-			$url .= "?v=" . $version;
-		}
+        $url = $this->packages->getUrl($path, $packageName);
+        if (strlen($version) > 0) {
+            $url .= '?v='.$version;
+        }
 
-		return $url;
-	}
+        return $url;
+    }
 }


### PR DESCRIPTION
Legger til versjonsnummer på alle assets for å tvinge browseren til å alltid laste ned nyeste versjon. Hvis browseren allerede har filen med riktig versjonnummer i cachen vil den ikke laste ned filen på nytt.

![image](https://cloud.githubusercontent.com/assets/6992505/26284155/f567383c-3e34-11e7-91f1-9cba8d49cfbe.png)
