### PR TITLE
Create lazy-src function

### DIFF
--- a/app/Resources/assets/js/lazy-src.js
+++ b/app/Resources/assets/js/lazy-src.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', lazyLoadImages);
+
+function lazyLoadImages() {
+  var lazyImages = document.querySelectorAll('img[lazy-src]');
+
+  for (var i = 0; i < lazyImages.length; i++) {
+    var img = lazyImages[i];
+    var src = img.getAttribute('lazy-src');
+
+    if (src) {
+      img.src = src;
+    }
+  }
+}

--- a/app/Resources/views/article/carousel.html.twig
+++ b/app/Resources/views/article/carousel.html.twig
@@ -2,7 +2,7 @@
     <div class="small-12 medium-8 medium-push-4 columns">
         <div class="news-carousel">
             {% for article in articles %}
-                <div><img src="{{ asset_with_version(article.imageMedium) }}"/></div>
+                <div><img {{ not loop.first ? 'lazy-src' : 'src' }}="{{ asset_with_version(article.imageMedium) }}"/></div>
             {% else %}
                 <div><h3>Ingen nyheter</h3></div>
             {% endfor %}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -88,6 +88,8 @@
 
 </script>
 
+<script src="{{ asset_with_version('js/lazy-src.js') }}"></script>
+
 {% block javascripts %}{% endblock %}
 
 </body>


### PR DESCRIPTION
Hvis `src` attributten i `<img>` byttes ut med `lazy-src` vil bildene starte å laste etter 'DOMContentLoaded'.
f.eks: `<img src="logo.png" />` -> `<img lazy-src="logo.png" />`.

Dette kan brukes til å forsinke lasting av ikke-viktige bilder. Bilder som er langt ned på siden, bilder som ligger lengre bak i bildekarusell osv.

TODO: Vente med å laste bilder til man er X pixler fra viewporten. Da unngår vi å laste bilder som vi aldri kommer til å se uansett.