### PR TITLE
Remove field of study and study year from assigned table

### DIFF
--- a/app/Resources/views/admission_admin/assigned_table.html.twig
+++ b/app/Resources/views/admission_admin/assigned_table.html.twig
@@ -8,8 +8,6 @@
         <th data-sort="string">Etternavn</th>
         <th data-sort="int">Tlf</th>
         <th data-sort="string">E-post</th>
-        <th data-sort="string">Linje</th>
-        <th data-sort="int">År</th>
         <th data-sort="int">Oppsatt dato</th>
         <th data-sort="string">Oppsatt rom</th>
         <th data-sort="string">Intervjues av</th>
@@ -26,8 +24,6 @@
             <td>{{ a.user.lastName }}</td>
             <td>{{ a.user.phone }}</td>
             <td>{{ a.user.email }}</td>
-            <td>{{ a.user.fieldOfStudy }}</td>
-            <td>{{ a.yearOfStudy }}</td>
 
             {% if a.interview.scheduled is not null %}
                 <td data-sort-value="{{ a.interview.scheduled.getTimestamp }}">

--- a/app/Resources/views/interview/schedule.html.twig
+++ b/app/Resources/views/interview/schedule.html.twig
@@ -25,7 +25,6 @@
                                 <th> E-post</th>
                                 <th> Linje</th>
                                 <th> År</th>
-                                <th> Tidligere deltagelse</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -37,12 +36,6 @@
                                 <td> {{ u.email }} </td>
                                 <td> {{ u.fieldOfStudy }} </td>
                                 <td> {{ application.yearOfStudy }} </td>
-
-                                {% if u.assistantHistories|length %}
-                                    <td> Ja</td>
-                                {% else %}
-                                    <td> Nei</td>
-                                {% endif %}
                             </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
Linje og år tar mye plass i tabellen (fordelt), men gir lite verdi.
Hvis man vil vite hvilken linje/år søkere er på kan man gå inn på profilen til brukeren, "sett opp" intervju eller på selve intervjusiden.

Og fjerne "Tidligere deltagelse" fra "sett opp intervju"-siden. De som har deltatt tidligere skal ikke på intervju.