### PR TITLE
Hide role updater for non-admins

### DIFF
--- a/app/Resources/views/profile/public_profile.html.twig
+++ b/app/Resources/views/profile/public_profile.html.twig
@@ -50,7 +50,7 @@
                                 bilde</a></li>
                         <li role="menuitem"><a href="{{ path('profile_certificate', { id: user.id} ) }}">Last
                                 ned attest</a></li>
-                        {% if not user_is_granted_admin(user) %}
+                        {% if is_granted_admin() and not user_is_granted_admin(user) %}
                             <li role="menuitem">
                                 <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false">Rediger
                                     rettighetsnivå</a>


### PR DESCRIPTION
Rolleoppdatering skjer nå helautomatisk. Hvis man endrer en rolle manuelt vil den bli overskrevet neste time, så det er ikke noe poeng å vise denne dropdownen lengre.