### PR TITLE
Update account number label on receipt form

### DIFF
--- a/app/Resources/assets/scss/partials/_typography.scss
+++ b/app/Resources/assets/scss/partials/_typography.scss
@@ -23,3 +23,11 @@
 .text-bold {
   font-weight: bold;
 }
+
+.text-link {
+  color: $primary-color;
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/app/Resources/views/receipt/create_receipt.html.twig
+++ b/app/Resources/views/receipt/create_receipt.html.twig
@@ -19,10 +19,19 @@
 
     <div class="row">
         <div class="small-8 medium-3 columns">
-            {{ form_row(form.user) }}
+            {% if app.user.accountNumber %}
+                <div id="accountNumberInfo">
+                    Ditt kontonummer er <span class="text-bold">{{ app.user.accountNumber }}</span> <span id="changeAccountNumber" class="text-link">Endre</span>
+                </div>
+                <div id="accountNumberForm" class="hide">
+                    {{ form_row(form.user) }}
+                </div>
+            {% else %}
+                {{ form_row(form.user) }}
+            {% endif %}
         </div>
     </div>
-
+<br>
     <div class="row">
         <div class="small-12 columns">
             <div>
@@ -38,3 +47,12 @@
     <br>
     <button class="button success">Be om refusjon</button>
 {{ form_end(form) }}
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        $('#changeAccountNumber').click(function() {
+          $('#accountNumberForm').show();
+          $('#accountNumberInfo').hide();
+        });
+    });
+</script>

--- a/app/Resources/views/receipt/my_receipts.html.twig
+++ b/app/Resources/views/receipt/my_receipts.html.twig
@@ -65,10 +65,13 @@
                 <hr>
             </div>
 
-            <div class="small-12 medium-12 large-8 columns">
+            <div class="small-12 columns">
 
                 <h3>Mine utlegg</h3>
                 <a href="#receipt-form" class="text-success" onclick="toggleForm()"><i class="fa fa-plus"></i> Nytt utlegg</a>
+                {% if app.user.accountNumber %}
+                    <span class="float-right">Kontonummer: {{ app.user.accountNumber }}</span>
+                {% endif %}
 
             </div>
         </div>

--- a/src/AppBundle/Form/Type/AccountNumberType.php
+++ b/src/AppBundle/Form/Type/AccountNumberType.php
@@ -13,7 +13,7 @@ class AccountNumberType extends AbstractType
     {
         $builder
             ->add('account_number', 'text', array(
-                'label' => 'Kontonummer',
+                'label' => 'Endre ditt kontonummer. Alle dine utlegg vil bli refundert hit',
                 'required' => true,
                 'attr' => array('oninput' => 'validateBankAccountNumber(this)'),
             ));

--- a/src/AppBundle/Form/Type/AccountNumberType.php
+++ b/src/AppBundle/Form/Type/AccountNumberType.php
@@ -13,7 +13,7 @@ class AccountNumberType extends AbstractType
     {
         $builder
             ->add('account_number', 'text', array(
-                'label' => 'Endre ditt kontonummer. Alle dine utlegg vil bli refundert hit',
+                'label' => 'Kontonummer (alle dine utlegg vil bli refundert hit)',
                 'required' => true,
                 'attr' => array('oninput' => 'validateBankAccountNumber(this)'),
             ));


### PR DESCRIPTION
For å gjøre det tydeligere at kontonummeret hører til brukeren, ikke til en enkelt kvittering.
Fixes #664 