### PR TITLE
Update teamInterest label on existing assistant application form

### DIFF
--- a/app/Resources/views/admission/existingUser.html.twig
+++ b/app/Resources/views/admission/existingUser.html.twig
@@ -66,7 +66,12 @@
 
             <div class="row">
                 <div class="small-12 medium-12 large-12 columns">
-                    {{ form_row(form.applicationPractical.teamInterest) }}
+                    <label class="question-label">
+                        Kunne du tenke deg å jobbe med organiseringen av Vektorprogrammet?<br>
+                        Dette innebærer et verv i et at Vektorprogrammets team
+                    </label>
+                    {{ form_widget(form.applicationPractical.teamInterest) }}
+                    {{ form_errors(form.applicationPractical.teamInterest) }}
                 </div>
             </div>
 

--- a/src/AppBundle/Controller/AdmissionController.php
+++ b/src/AppBundle/Controller/AdmissionController.php
@@ -108,6 +108,7 @@ class AdmissionController extends Controller
         $form = $this->createForm(new ApplicationExistingUserType(), $application, array(
             'validation_groups' => array('admission_existing'),
         ));
+        $form->remove('applicationPractical.teamInterest');
         $form->handleRequest($request);
 
         if ($form->isValid()) {


### PR DESCRIPTION
Endret label i søknad for tidligere assistenter:
`Legg til personen i teaminteresse-listen?` -> `Kunne du tenke deg å jobbe med organiseringen av Vektorprogrammet? Dette innebærer et verv i et at Vektorprogrammets team`