### PR TITLE
Simplify interview availability question

### DIFF
--- a/app/DoctrineMigrations/Version20180125205543.php
+++ b/app/DoctrineMigrations/Version20180125205543.php
@@ -58,19 +58,19 @@ CHANGE friday friday TINYINT(1) DEFAULT \'1\' NOT NULL');
 
         $this->addSql('ALTER TABLE application CHANGE monday monday VARCHAR(255) DEFAULT NULL, CHANGE tuesday tuesday VARCHAR(255) DEFAULT NULL, CHANGE wednesday wednesday VARCHAR(255) DEFAULT NULL, CHANGE thursday thursday VARCHAR(255) DEFAULT NULL, CHANGE friday friday VARCHAR(255) DEFAULT NULL');
 
-        $this->addSql('UPDATE application SET monday="Bra" WHERE monday=1');
-        $this->addSql('UPDATE application SET monday="Ikke" WHERE monday=0');
+        $this->addSql('UPDATE application SET monday="Bra" WHERE monday="1"');
+        $this->addSql('UPDATE application SET monday="Ikke" WHERE monday="0"');
 
-        $this->addSql('UPDATE application SET tuesday="Bra" WHERE tuesday=1');
-        $this->addSql('UPDATE application SET tuesday="Ikke" WHERE tuesday=0');
+        $this->addSql('UPDATE application SET tuesday="Bra" WHERE tuesday="1"');
+        $this->addSql('UPDATE application SET tuesday="Ikke" WHERE tuesday="0"');
 
-        $this->addSql('UPDATE application SET wednesday="Bra" WHERE wednesday=1');
-        $this->addSql('UPDATE application SET wednesday="Ikke" WHERE wednesday=0');
+        $this->addSql('UPDATE application SET wednesday="Bra" WHERE wednesday="1"');
+        $this->addSql('UPDATE application SET wednesday="Ikke" WHERE wednesday="0"');
 
-        $this->addSql('UPDATE application SET thursday="Bra" WHERE thursday=1');
-        $this->addSql('UPDATE application SET thursday="Ikke" WHERE thursday=0');
+        $this->addSql('UPDATE application SET thursday="Bra" WHERE thursday="1"');
+        $this->addSql('UPDATE application SET thursday="Ikke" WHERE thursday="0"');
 
-        $this->addSql('UPDATE application SET friday="Bra" WHERE friday=1');
-        $this->addSql('UPDATE application SET friday="Ikke" WHERE friday=0');
+        $this->addSql('UPDATE application SET friday="Bra" WHERE friday="1"');
+        $this->addSql('UPDATE application SET friday="Ikke" WHERE friday="0"');
     }
 }

--- a/app/DoctrineMigrations/Version20180125205543.php
+++ b/app/DoctrineMigrations/Version20180125205543.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180125205543 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('UPDATE application SET monday=1 WHERE monday="Bra"');
+        $this->addSql('UPDATE application SET monday=0 WHERE monday="Ikke"');
+        $this->addSql('UPDATE application SET monday=1 WHERE monday is NULL');
+
+        $this->addSql('UPDATE application SET tuesday=1 WHERE tuesday="Bra"');
+        $this->addSql('UPDATE application SET tuesday=0 WHERE tuesday="Ikke"');
+        $this->addSql('UPDATE application SET tuesday=1 WHERE tuesday is NULL');
+
+        $this->addSql('UPDATE application SET wednesday=1 WHERE wednesday="Bra"');
+        $this->addSql('UPDATE application SET wednesday=0 WHERE wednesday="Ikke"');
+        $this->addSql('UPDATE application SET wednesday=1 WHERE wednesday is NULL');
+
+
+        $this->addSql('UPDATE application SET thursday=1 WHERE thursday="Bra"');
+        $this->addSql('UPDATE application SET thursday=0 WHERE thursday="Ikke"');
+        $this->addSql('UPDATE application SET thursday=1 WHERE thursday is NULL');
+
+        $this->addSql('UPDATE application SET friday=1 WHERE friday="Bra"');
+        $this->addSql('UPDATE application SET friday=0 WHERE friday="Ikke"');
+        $this->addSql('UPDATE application SET friday=1 WHERE friday is NULL');
+
+
+        $this->addSql('ALTER TABLE application
+CHANGE monday monday TINYINT(1) DEFAULT \'1\' NOT NULL,
+CHANGE tuesday tuesday TINYINT(1) DEFAULT \'1\' NOT NULL,
+CHANGE wednesday wednesday TINYINT(1) DEFAULT \'1\' NOT NULL,
+CHANGE thursday thursday TINYINT(1) DEFAULT \'1\' NOT NULL,
+CHANGE friday friday TINYINT(1) DEFAULT \'1\' NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE application CHANGE monday monday VARCHAR(255) DEFAULT NULL, CHANGE tuesday tuesday VARCHAR(255) DEFAULT NULL, CHANGE wednesday wednesday VARCHAR(255) DEFAULT NULL, CHANGE thursday thursday VARCHAR(255) DEFAULT NULL, CHANGE friday friday VARCHAR(255) DEFAULT NULL');
+
+        $this->addSql('UPDATE application SET monday="Bra" WHERE monday=1');
+        $this->addSql('UPDATE application SET monday="Ikke" WHERE monday=0');
+
+        $this->addSql('UPDATE application SET tuesday="Bra" WHERE tuesday=1');
+        $this->addSql('UPDATE application SET tuesday="Ikke" WHERE tuesday=0');
+
+        $this->addSql('UPDATE application SET wednesday="Bra" WHERE wednesday=1');
+        $this->addSql('UPDATE application SET wednesday="Ikke" WHERE wednesday=0');
+
+        $this->addSql('UPDATE application SET thursday="Bra" WHERE thursday=1');
+        $this->addSql('UPDATE application SET thursday="Ikke" WHERE thursday=0');
+
+        $this->addSql('UPDATE application SET friday="Bra" WHERE friday=1');
+        $this->addSql('UPDATE application SET friday="Ikke" WHERE friday=0');
+    }
+}

--- a/app/Resources/assets/scss/app.scss
+++ b/app/Resources/assets/scss/app.scss
@@ -419,6 +419,10 @@ ul.alternatives {
   }
 }
 
+.interview-day:not(:last-of-type) .interview-days-checkbox[type="checkbox"] {
+  margin: 0;
+}
+
 .radio-grid {
   margin-left: 0;
   list-style-type: none;

--- a/app/Resources/assets/scss/app.scss
+++ b/app/Resources/assets/scss/app.scss
@@ -426,10 +426,6 @@ ul.alternatives {
 .radio-grid {
   margin-left: 0;
   list-style-type: none;
-/*  &>div>li{
-    margin-right: 1rem;
-    display:inline-block;
-  }*/
   label{
     margin-right: 1rem;
     display: inline-block;

--- a/app/Resources/assets/scss/app.scss
+++ b/app/Resources/assets/scss/app.scss
@@ -423,14 +423,6 @@ ul.alternatives {
   margin: 0;
 }
 
-.radio-grid {
-  margin-left: 0;
-  list-style-type: none;
-  label{
-    margin-right: 1rem;
-    display: inline-block;
-  }
-}
 
 // Utils
 // - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/Resources/assets/scss/app.scss
+++ b/app/Resources/assets/scss/app.scss
@@ -422,9 +422,13 @@ ul.alternatives {
 .radio-grid {
   margin-left: 0;
   list-style-type: none;
-  &>div>li{
+/*  &>div>li{
     margin-right: 1rem;
     display:inline-block;
+  }*/
+  label{
+    margin-right: 1rem;
+    display: inline-block;
   }
 }
 

--- a/app/Resources/views/admission/admission_existing_email.html.twig
+++ b/app/Resources/views/admission/admission_existing_email.html.twig
@@ -23,11 +23,11 @@ Dobbel stilling: {{ application.doublePosition ? 'Ja' : 'Nei' }}
 Ønsket undervisningsspråk: {{ application.language }}
 
 Dager som passer
-Mandag: {{ application.monday }}
-Tirsdag: {{ application.tuesday }}
-Onsdag: {{ application.wednesday }}
-Torsdag: {{ application.thursday }}
-Fredag: {{ application.friday }}
+Mandag: {{ application.monday ? "Bra" : "Ikke" }}
+Tirsdag: {{ application.tuesday ? "Bra" : "Ikke" }}
+Onsdag: {{ application.wednesday ? "Bra" : "Ikke" }}
+Torsdag: {{ application.thursday ? "Bra" : "Ikke" }}
+Fredag: {{ application.friday ? "Bra" : "Ikke" }}
 
 ---
 

--- a/app/Resources/views/admission/existingUser.html.twig
+++ b/app/Resources/views/admission/existingUser.html.twig
@@ -38,9 +38,7 @@
             <div class="row">
                 <div class="small-12 columns">
                     <label class="question-label">Hvilke dager passer IKKE for deg?</label>
-                    <ul class="radio-grid">
                         {{ form_widget(form.applicationPractical.days) }}
-                    </ul>
                 </div>
             </div>
 

--- a/app/Resources/views/admission/existingUser.html.twig
+++ b/app/Resources/views/admission/existingUser.html.twig
@@ -6,7 +6,7 @@
 
 {# Form themes user to modify the templates of the various form components #}
 {% form_theme form 'form/interview_layout.html.twig' %}
-{% form_theme form.applicationPractical.days 'form/components/radio_grid_layout.html.twig' %}
+{% form_theme form.applicationPractical.days 'form/components/days_checkbox.html.twig' %}
 
 {% block body %}
     <div class="row">

--- a/app/Resources/views/admission_admin/application.html.twig
+++ b/app/Resources/views/admission_admin/application.html.twig
@@ -49,23 +49,23 @@
             <table width="100%">
                 <tr>
                     <td><b>Mandag</b></td>
-                    <td>{{ application.monday }}</td>
+                    <td>{{ application.monday ? "Bra" : "Ikke" }}</td>
                 </tr>
                 <tr>
                     <td><b>Tirsdag</b></td>
-                    <td>{{ application.tuesday }}</td>
+                    <td>{{ application.tuesday ? "Bra" : "Ikke" }}</td>
                 </tr>
                 <tr>
                     <td><b>Onsdag</b></td>
-                    <td>{{ application.wednesday }}</td>
+                    <td>{{ application.wednesday ? "Bra" : "Ikke" }}</td>
                 </tr>
                 <tr>
                     <td><b>Torsdag</b></td>
-                    <td>{{ application.thursday }}</td>
+                    <td>{{ application.thursday ? "Bra" : "Ikke" }}</td>
                 </tr>
                 <tr>
                     <td><b>Fredag</b></td>
-                    <td>{{ application.friday }}</td>
+                    <td>{{ application.friday ? "Bra" : "Ikke" }}</td>
                 </tr>
             </table>
         </div>

--- a/app/Resources/views/form/components/days_checkbox.html.twig
+++ b/app/Resources/views/form/components/days_checkbox.html.twig
@@ -1,0 +1,20 @@
+{% block form_row %}
+    {% spaceless %}
+        <div class="interview-day">
+            {{ form_errors(form) }}
+            {{ form_widget(form) }}
+        </div>
+    {% endspaceless %}
+{% endblock form_row %}
+
+{% block checkbox_widget -%}
+    {% spaceless %}
+        <input type="checkbox"
+               class="interview-days-checkbox"
+                {{ block('widget_attributes') }}
+                {% if value is defined %} value="{{ value }}"{% endif %}
+                {% if checked %} checked="checked"{% endif %}
+        />
+        {{ form_label(form) }}
+    {% endspaceless %}
+{%- endblock checkbox_widget %}

--- a/app/Resources/views/interview/conduct.html.twig
+++ b/app/Resources/views/interview/conduct.html.twig
@@ -6,7 +6,7 @@
 
 {# Form themes user to modify the templates of the various form components #}
 {% form_theme form 'form/interview_layout.html.twig' %}
-{% form_theme form.applicationPractical.days 'form/components/radio_grid_layout.html.twig' %}
+{% form_theme form.applicationPractical.days 'form/components/days_checkbox.html.twig' %}
 
 {% block body %}
     <p></p>
@@ -75,9 +75,7 @@
                 <div class="row">
                     <div class="small-12 columns">
                         <label class="question-label">{{ form.applicationPractical.days.vars.label }}</label>
-                        <ul class="radio-grid">
-                            {{ form_widget(form.applicationPractical.days) }}
-                        </ul>
+                        {{ form_row(form.applicationPractical.days) }}
                     </div>
                 </div>
 

--- a/app/Resources/views/interview/interview_summary_email.html.twig
+++ b/app/Resources/views/interview/interview_summary_email.html.twig
@@ -11,11 +11,11 @@ Linje: {{ user.fieldOfStudy.name }} ({{ user.fieldOfStudy.shortName }})
 Kjønn: {{ user.gender == 1 ? 'Dame' : 'Mann' }}
 
 Dager som passer
-Mandag: {{ application.monday }}
-Tirsdag: {{ application.tuesday }}
-Onsdag: {{ application.wednesday }}
-Torsdag: {{ application.thursday }}
-Fredag: {{ application.friday }}
+Mandag: {{ application.monday ? "Bra" : "Ikke" }}
+Tirsdag: {{ application.tuesday ? "Bra" : "Ikke" }}
+Onsdag: {{ application.wednesday ? "Bra" : "Ikke" }}
+Torsdag: {{ application.thursday ? "Bra" : "Ikke" }}
+Fredag: {{ application.friday ? "Bra" : "Ikke" }}
 
 Dobbel stilling: {{ application.doublePosition ? 'Ja' : 'Nei' }}
 {% if application.preferredGroup %}

--- a/app/Resources/views/interview/show.html.twig
+++ b/app/Resources/views/interview/show.html.twig
@@ -74,11 +74,11 @@
                             </thead>
                             <tbody>
                             <tr>
-                                <td>{{ application.monday }}</td>
-                                <td>{{ application.tuesday }}</td>
-                                <td>{{ application.wednesday }}</td>
-                                <td>{{ application.thursday }}</td>
-                                <td>{{ application.friday }}</td>
+                                <td>{{ application.monday ? "Bra" : "Ikke" }}</td>
+                                <td>{{ application.tuesday ? "Bra" : "Ikke" }}</td>
+                                <td>{{ application.wednesday ? "Bra" : "Ikke" }}</td>
+                                <td>{{ application.thursday ? "Bra" : "Ikke" }}</td>
+                                <td>{{ application.friday ? "Bra" : "Ikke" }}</td>
                             </tr>
                             </tbody>
                         </table>

--- a/app/Resources/views/substitute/index.html.twig
+++ b/app/Resources/views/substitute/index.html.twig
@@ -89,11 +89,11 @@
                             <td>{{ sub.user.fieldOfStudy }}</td>
                             <td>{{ sub.yearOfStudy }}</td>
                             <td>{{ sub.language }}</td>
-                            <td>{{ sub.monday }}</td>
-                            <td>{{ sub.tuesday }}</td>
-                            <td>{{ sub.wednesday }}</td>
-                            <td>{{ sub.thursday }}</td>
-                            <td>{{ sub.friday }}</td>
+                            <td>{{ sub.monday ? "Bra" : "Ikke" }}</td>
+                            <td>{{ sub.tuesday ? "Bra" : "Ikke" }}</td>
+                            <td>{{ sub.wednesday ? "Bra" : "Ikke" }}</td>
+                            <td>{{ sub.thursday ? "Bra" : "Ikke" }}</td>
+                            <td>{{ sub.friday ? "Bra" : "Ikke" }}</td>
                             {% if is_granted_team_leader() %}
                                 <td>
                                     <form method="POST"

--- a/app/Resources/views/substitute/modify_substitute.twig
+++ b/app/Resources/views/substitute/modify_substitute.twig
@@ -6,7 +6,8 @@
 
 {# Form themes user to modify the templates of the various form components #}
 {% form_theme form 'form/interview_layout.html.twig' %}
-{% form_theme form.days 'form/components/radio_grid_layout.html.twig' %}
+{% form_theme form.days 'form/components/days_checkbox.html.twig' %}
+
 
 {% block body %}
     <div class="row">
@@ -19,9 +20,7 @@
                             <div class="small-12 columns">
                                 {{ form_start(form) }}
                                 <label class="question-label">{{ form.days.vars.label }}</label>
-                                <ul class="radio-grid">
                                     {{ form_widget(form.days) }}
-                                </ul>
                                 {{ form_errors(form) }}
                                 {{ form_end(form) }}
                             </div>

--- a/src/AppBundle/AssistantScheduling/Webapp/src/App.vue
+++ b/src/AppBundle/AssistantScheduling/Webapp/src/App.vue
@@ -76,11 +76,11 @@
                   preferredGroup: a.preferredGroup,
                   suitable: a.suitable,
                   score: a.previousParticipation ? 20 : a.score,
-                  monday: a.availability.Monday === 1,
-                  tuesday: a.availability.Tuesday === 1,
-                  wednesday: a.availability.Wednesday === 1,
-                  thursday: a.availability.Thursday === 1,
-                  friday: a.availability.Friday === 1
+                  monday: a.availability.Monday,
+                  tuesday: a.availability.Tuesday,
+                  wednesday: a.availability.Wednesday,
+                  thursday: a.availability.Thursday,
+                  friday: a.availability.Friday
                 }
               });
             });

--- a/src/AppBundle/Controller/AssistantSchedulingController.php
+++ b/src/AppBundle/Controller/AssistantSchedulingController.php
@@ -86,11 +86,11 @@ class AssistantSchedulingController extends Controller
         return new JsonResponse(json_encode($schools));
     }
 
-	/**
-	 * @param SchoolCapacity[] $schoolCapacities
-	 *
-	 * @return array
-	 */
+    /**
+     * @param SchoolCapacity[] $schoolCapacities
+     *
+     * @return array
+     */
     private function generateSchoolsFromSchoolCapacities($schoolCapacities)
     {
         //Use schoolCapacities to create School objects for the SA-Algorithm

--- a/src/AppBundle/Controller/AssistantSchedulingController.php
+++ b/src/AppBundle/Controller/AssistantSchedulingController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Application;
 use AppBundle\AssistantScheduling\Assistant;
 use AppBundle\AssistantScheduling\School;
+use AppBundle\Entity\SchoolCapacity;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -47,12 +48,11 @@ class AssistantSchedulingController extends Controller
             }
 
             $availability = array();
-            $availabilityBooleans = ['Ikke', 'Bra']; /* False, True */
-            $availability['Monday'] = array_search($application->isMonday(), $availabilityBooleans);
-            $availability['Tuesday'] = array_search($application->isTuesday(), $availabilityBooleans);
-            $availability['Wednesday'] = array_search($application->isWednesday(), $availabilityBooleans);
-            $availability['Thursday'] = array_search($application->isThursday(), $availabilityBooleans);
-            $availability['Friday'] = array_search($application->isFriday(), $availabilityBooleans);
+            $availability['Monday'] = $application->isMonday();
+            $availability['Tuesday'] = $application->isTuesday();
+            $availability['Wednesday'] = $application->isWednesday();
+            $availability['Thursday'] = $application->isThursday();
+            $availability['Friday'] = $application->isFriday();
 
             $assistant = new Assistant();
             $assistant->setName($application->getUser()->getFullName());
@@ -86,17 +86,22 @@ class AssistantSchedulingController extends Controller
         return new JsonResponse(json_encode($schools));
     }
 
+	/**
+	 * @param SchoolCapacity[] $schoolCapacities
+	 *
+	 * @return array
+	 */
     private function generateSchoolsFromSchoolCapacities($schoolCapacities)
     {
         //Use schoolCapacities to create School objects for the SA-Algorithm
         $schools = array();
         foreach ($schoolCapacities as $sc) {
             $capacityDays = array();
-            $capacityDays['Monday'] = $sc->isMonday();
-            $capacityDays['Tuesday'] = $sc->isTuesday();
-            $capacityDays['Wednesday'] = $sc->isWednesday();
-            $capacityDays['Thursday'] = $sc->isThursday();
-            $capacityDays['Friday'] = $sc->isFriday();
+            $capacityDays['Monday'] = $sc->getMonday();
+            $capacityDays['Tuesday'] = $sc->getTuesday();
+            $capacityDays['Wednesday'] = $sc->getWednesday();
+            $capacityDays['Thursday'] = $sc->getThursday();
+            $capacityDays['Friday'] = $sc->getFriday();
 
             $capacity = array();
             $capacity[1] = $capacityDays;

--- a/src/AppBundle/Controller/AssistantSchedulingController.php
+++ b/src/AppBundle/Controller/AssistantSchedulingController.php
@@ -48,11 +48,11 @@ class AssistantSchedulingController extends Controller
 
             $availability = array();
             $availabilityBooleans = ['Ikke', 'Bra']; /* False, True */
-            $availability['Monday'] = array_search($application->getMonday(), $availabilityBooleans);
-            $availability['Tuesday'] = array_search($application->getTuesday(), $availabilityBooleans);
-            $availability['Wednesday'] = array_search($application->getWednesday(), $availabilityBooleans);
-            $availability['Thursday'] = array_search($application->getThursday(), $availabilityBooleans);
-            $availability['Friday'] = array_search($application->getFriday(), $availabilityBooleans);
+            $availability['Monday'] = array_search($application->isMonday(), $availabilityBooleans);
+            $availability['Tuesday'] = array_search($application->isTuesday(), $availabilityBooleans);
+            $availability['Wednesday'] = array_search($application->isWednesday(), $availabilityBooleans);
+            $availability['Thursday'] = array_search($application->isThursday(), $availabilityBooleans);
+            $availability['Friday'] = array_search($application->isFriday(), $availabilityBooleans);
 
             $assistant = new Assistant();
             $assistant->setName($application->getUser()->getFullName());
@@ -92,11 +92,11 @@ class AssistantSchedulingController extends Controller
         $schools = array();
         foreach ($schoolCapacities as $sc) {
             $capacityDays = array();
-            $capacityDays['Monday'] = $sc->getMonday();
-            $capacityDays['Tuesday'] = $sc->getTuesday();
-            $capacityDays['Wednesday'] = $sc->getWednesday();
-            $capacityDays['Thursday'] = $sc->getThursday();
-            $capacityDays['Friday'] = $sc->getFriday();
+            $capacityDays['Monday'] = $sc->isMonday();
+            $capacityDays['Tuesday'] = $sc->isTuesday();
+            $capacityDays['Wednesday'] = $sc->isWednesday();
+            $capacityDays['Thursday'] = $sc->isThursday();
+            $capacityDays['Friday'] = $sc->isFriday();
 
             $capacity = array();
             $capacity[1] = $capacityDays;

--- a/src/AppBundle/Controller/InterviewController.php
+++ b/src/AppBundle/Controller/InterviewController.php
@@ -353,7 +353,9 @@ class InterviewController extends Controller
             throw $this->createNotFoundException();
         }
 
-        $form = $this->createForm(new InterviewNewTimeType(), $interview);
+        $form = $this->createForm(new InterviewNewTimeType(), $interview, array(
+            "validation_groups" => array("newTimeRequest")
+        ));
         $form->handleRequest($request);
 
         if ($form->isValid()) {

--- a/src/AppBundle/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadApplicationData.php
@@ -20,11 +20,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $application0->setPreviousParticipation(false);
         $application0->setYearOfStudy(1);
         $application0->setSemester($this->getReference('semester-current'));
-        $application0->setMonday('Ikke');
-        $application0->setTuesday('Ikke');
-        $application0->setWednesday('Ikke');
-        $application0->setThursday('Ikke');
-        $application0->setFriday('Bra');
+        $application0->setMonday(false);
+        $application0->setTuesday(false);
+        $application0->setWednesday(false);
+        $application0->setThursday(false);
+        $application0->setFriday(true);
         $application0->setSubstitute(true);
 
         $manager->persist($application0);
@@ -34,11 +34,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $application1->setPreviousParticipation(true);
         $application1->setYearOfStudy(1);
         $application1->setSemester($this->getReference('semester-5'));
-        $application1->setMonday('Bra');
-        $application1->setTuesday('Ikke');
-        $application1->setWednesday('Bra');
-        $application1->setThursday('Ikke');
-        $application1->setFriday('Bra');
+        $application1->setMonday(true);
+        $application1->setTuesday(false);
+        $application1->setWednesday(true);
+        $application1->setThursday(false);
+        $application1->setFriday(true);
         $application0->setSubstitute(true);
 
         $manager->persist($application1);
@@ -48,11 +48,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $application2->setPreviousParticipation(false);
         $application2->setYearOfStudy(1);
         $application2->setSemester($this->getReference('semester-1'));
-        $application2->setMonday('Bra');
-        $application2->setTuesday('Bra');
-        $application2->setWednesday('Ikke');
-        $application2->setThursday('Ikke');
-        $application2->setFriday('Bra');
+        $application2->setMonday(true);
+        $application2->setTuesday(true);
+        $application2->setWednesday(false);
+        $application2->setThursday(false);
+        $application2->setFriday(true);
         $application0->setSubstitute(true);
 
         $manager->persist($application2);
@@ -91,11 +91,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $interview3->setInterviewScore($intScore);
 
         // The interview practical
-        $application3->setMonday('Bra');
-        $application3->setTuesday('Bra');
-        $application3->setWednesday('Ikke');
-        $application3->setThursday('Bra');
-        $application3->setFriday('Ikke');
+        $application3->setMonday(true);
+        $application3->setTuesday(true);
+        $application3->setWednesday(false);
+        $application3->setThursday(true);
+        $application3->setFriday(false);
         $application3->setHeardAboutFrom(array( 'Stand' ));
         $application3->setLanguage('Norsk og engelsk');
         $application3->setPreferredGroup('Bolk 1');
@@ -137,11 +137,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $interview4->setInterviewScore($intScore);
 
         // The interview practical
-        $application4->setMonday('Bra');
-        $application4->setTuesday('Bra');
-        $application4->setWednesday('Ikke');
-        $application4->setThursday('Bra');
-        $application4->setFriday('Ikke');
+        $application4->setMonday(true);
+        $application4->setTuesday(true);
+        $application4->setWednesday(false);
+        $application4->setThursday(true);
+        $application4->setFriday(false);
         $application4->setHeardAboutFrom(array( 'Stand' ));
         $application4->setLanguage('Norsk');
         $application4->setPreferredGroup('Bolk 1');
@@ -190,11 +190,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $application20->setYearOfStudy(1);
         $application20->setSemester($this->getReference('semester-current'));
 
-        $application20->setMonday('Ikke');
-        $application20->setTuesday('Ikke');
-        $application20->setWednesday('Ikke');
-        $application20->setThursday('Ikke');
-        $application20->setFriday('Bra');
+        $application20->setMonday(false);
+        $application20->setTuesday(false);
+        $application20->setWednesday(false);
+        $application20->setThursday(false);
+        $application20->setFriday(true);
         $application20->setHeardAboutFrom(array( 'Stand' ));
         $application20->setLanguage('Norsk');
         $application20->setPreferredGroup('Bolk 1');

--- a/src/AppBundle/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadApplicationData.php
@@ -253,11 +253,11 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $application->setSemester($this->getReference('semester-current'));
         $randomArr = array( true, false, false, false, false );
         shuffle($randomArr);
-        $application->setMonday($randomArr[0] || mt_rand(0, 100) < 20 ? 'Bra' : 'Ikke');
-        $application->setTuesday($randomArr[1] || mt_rand(0, 100) < 20 ? 'Bra' : 'Ikke');
-        $application->setWednesday($randomArr[2] || mt_rand(0, 100) < 20 ? 'Bra' : 'Ikke');
-        $application->setThursday($randomArr[3] || mt_rand(0, 100) < 20 ? 'Bra' : 'Ikke');
-        $application->setFriday($randomArr[4] || mt_rand(0, 100) < 20 ? 'Bra' : 'Ikke');
+        $application->setMonday($randomArr[0] || mt_rand(0, 100) < 20);
+        $application->setTuesday($randomArr[1] || mt_rand(0, 100) < 20);
+        $application->setWednesday($randomArr[2] || mt_rand(0, 100) < 20);
+        $application->setThursday($randomArr[3] || mt_rand(0, 100) < 20);
+        $application->setFriday($randomArr[4] || mt_rand(0, 100) < 20);
         $application->setHeardAboutFrom(array( 'Stand' ));
         $application->setLanguage($randomArr[0] || mt_rand(0, 100) < 20 ? 'Norsk' : 'Engelsk');
         $application->setPreferredGroup(mt_rand(0, 100) < 50 ? 'Bolk 1' : 'Bolk 2');

--- a/src/AppBundle/Entity/Application.php
+++ b/src/AppBundle/Entity/Application.php
@@ -30,31 +30,31 @@ class Application
     private $yearOfStudy;
 
     /**
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(type="boolean", options={"default"=true}))
      * @var bool
      */
     private $monday;
 
     /**
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(type="boolean", options={"default"=true}))
      * @var bool
      */
     private $tuesday;
 
     /**
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(type="boolean", options={"default"=true}))
      * @var bool
      */
     private $wednesday;
 
     /**
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(type="boolean", options={"default"=true}))
      * @var bool
      */
     private $thursday;
 
     /**
-     * @ORM\Column(type="boolean")
+     * @ORM\Column(type="boolean", options={"default"=true}))
      * @var bool
      */
     private $friday;

--- a/src/AppBundle/Entity/Application.php
+++ b/src/AppBundle/Entity/Application.php
@@ -30,32 +30,32 @@ class Application
     private $yearOfStudy;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     * @Assert\NotBlank(groups={"interview", "admission_existing"}, message="Dette feltet kan ikke være tomt.")
+     * @ORM\Column(type="boolean")
+     * @var bool
      */
     private $monday;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     * @Assert\NotBlank(groups={"interview", "admission_existing"}, message="Dette feltet kan ikke være tomt.")
+     * @ORM\Column(type="boolean")
+     * @var bool
      */
     private $tuesday;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     * @Assert\NotBlank(groups={"interview", "admission_existing"}, message="Dette feltet kan ikke være tomt.")
+     * @ORM\Column(type="boolean")
+     * @var bool
      */
     private $wednesday;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     * @Assert\NotBlank(groups={"interview", "admission_existing"}, message="Dette feltet kan ikke være tomt.")
+     * @ORM\Column(type="boolean")
+     * @var bool
      */
     private $thursday;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     * @Assert\NotBlank(groups={"interview", "admission_existing"}, message="Dette feltet kan ikke være tomt.")
+     * @ORM\Column(type="boolean")
+     * @var bool
      */
     private $friday;
 
@@ -145,6 +145,11 @@ class Application
         $this->teamInterest = false;
         $this->wantsNewsletter = false;
         $this->specialNeeds = '';
+        $this->monday = true;
+        $this->tuesday = true;
+        $this->wednesday = true;
+        $this->thursday = true;
+        $this->friday = true;
     }
 
     /**
@@ -190,84 +195,86 @@ class Application
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getMonday()
+    public function isMonday(): bool
     {
         return $this->monday;
     }
 
     /**
-     * @param string $monday
+     * @param bool $monday
      */
-    public function setMonday($monday)
+    public function setMonday(bool $monday)
     {
         $this->monday = $monday;
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getTuesday()
+    public function isTuesday(): bool
     {
         return $this->tuesday;
     }
 
     /**
-     * @param string $tuesday
+     * @param bool $tuesday
      */
-    public function setTuesday($tuesday)
+    public function setTuesday(bool $tuesday)
     {
         $this->tuesday = $tuesday;
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getWednesday()
+    public function isWednesday(): bool
     {
         return $this->wednesday;
     }
 
     /**
-     * @param string $wednesday
+     * @param bool $wednesday
      */
-    public function setWednesday($wednesday)
+    public function setWednesday(bool $wednesday)
     {
         $this->wednesday = $wednesday;
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getThursday()
+    public function isThursday(): bool
     {
         return $this->thursday;
     }
 
     /**
-     * @param string $thursday
+     * @param bool $thursday
      */
-    public function setThursday($thursday)
+    public function setThursday(bool $thursday)
     {
         $this->thursday = $thursday;
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getFriday()
+    public function isFriday(): bool
     {
         return $this->friday;
     }
 
     /**
-     * @param string $friday
+     * @param bool $friday
      */
-    public function setFriday($friday)
+    public function setFriday(bool $friday)
     {
         $this->friday = $friday;
     }
+
+
     /**
      * @return string
      */

--- a/src/AppBundle/Entity/Interview.php
+++ b/src/AppBundle/Entity/Interview.php
@@ -102,7 +102,7 @@ class Interview
     /**
      * @ORM\Column(type="string", length=2000)
      * @Assert\Length(max=2000)
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="Meldingsboksen kan ikke være tom")
      *
      * @var string
      */
@@ -547,7 +547,7 @@ class Interview
     /**
      * @param string $newTimeMessage
      */
-    public function setNewTimeMessage(string $newTimeMessage)
+    public function setNewTimeMessage($newTimeMessage)
     {
         $this->newTimeMessage = $newTimeMessage;
     }

--- a/src/AppBundle/Entity/Interview.php
+++ b/src/AppBundle/Entity/Interview.php
@@ -102,7 +102,7 @@ class Interview
     /**
      * @ORM\Column(type="string", length=2000)
      * @Assert\Length(max=2000)
-     * @Assert\NotBlank(message="Meldingsboksen kan ikke være tom")
+     * @Assert\NotBlank(groups={"newTimeRequest"}, message="Meldingsboksen kan ikke være tom")
      *
      * @var string
      */

--- a/src/AppBundle/Form/Type/DaysType.php
+++ b/src/AppBundle/Form/Type/DaysType.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -36,6 +37,60 @@ class DaysType extends AbstractType
             'label' => 'Fredag passer IKKE',
             'required' => false,
         ));
+
+        /* Invert the truth values */
+        $builder->get('monday')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($in) {
+                    return !$in; /* The object value displayed */
+                },
+                function ($in) {
+                    return !$in; /* The submitted value into the object */
+                }
+            ));
+
+
+        $builder->get('tuesday')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($in) {
+                    return !$in;
+                },
+                function ($in) {
+                    return !$in;
+                }
+            ));
+
+
+        $builder->get('wednesday')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($in) {
+                    return !$in;
+                },
+                function ($in) {
+                    return !$in;
+                }
+            ));
+
+
+        $builder->get('thursday')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($in) {
+                    return !$in;
+                },
+                function ($in) {
+                    return !$in;
+                }
+            ));
+
+        $builder->get('friday')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($in) {
+                    return !$in;
+                },
+                function ($in) {
+                    return !$in;
+                }
+            ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/src/AppBundle/Form/Type/DaysType.php
+++ b/src/AppBundle/Form/Type/DaysType.php
@@ -13,27 +13,27 @@ class DaysType extends AbstractType
     {
 
         $builder->add('monday', CheckboxType::class, array(
-            'label' => 'Mandag',
+            'label' => 'Mandag passer IKKE',
             'required' => false,
         ));
 
         $builder->add('tuesday', CheckboxType::class, array(
-            'label' => 'Tirsdag',
+            'label' => 'Tirsdag passer IKKE',
             'required' => false,
         ));
 
         $builder->add('wednesday', CheckboxType::class, array(
-            'label' => 'Onsdag',
+            'label' => 'Onsdag passer IKKE',
             'required' => false,
         ));
 
         $builder->add('thursday', CheckboxType::class, array(
-            'label' => 'Torsdag',
+            'label' => 'Torsdag passer IKKE',
             'required' => false,
         ));
 
         $builder->add('friday', CheckboxType::class, array(
-            'label' => 'Fredag',
+            'label' => 'Fredag passer IKKE',
             'required' => false,
         ));
     }

--- a/src/AppBundle/Form/Type/DaysType.php
+++ b/src/AppBundle/Form/Type/DaysType.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -10,39 +11,30 @@ class DaysType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $workChoices = array(
-            'Bra' => 'Passer bra',
-            'Ikke' => 'Passer ikke',
-        );
 
-        $builder->add('monday', 'choice', array(
+        $builder->add('monday', CheckboxType::class, array(
             'label' => 'Mandag',
-            'choices' => $workChoices,
-            'expanded' => true,
+            'required' => false,
         ));
 
-        $builder->add('tuesday', 'choice', array(
+        $builder->add('tuesday', CheckboxType::class, array(
             'label' => 'Tirsdag',
-            'choices' => $workChoices,
-            'expanded' => true,
+            'required' => false,
         ));
 
-        $builder->add('wednesday', 'choice', array(
+        $builder->add('wednesday', CheckboxType::class, array(
             'label' => 'Onsdag',
-            'choices' => $workChoices,
-            'expanded' => true,
+            'required' => false,
         ));
 
-        $builder->add('thursday', 'choice', array(
+        $builder->add('thursday', CheckboxType::class, array(
             'label' => 'Torsdag',
-            'choices' => $workChoices,
-            'expanded' => true,
+            'required' => false,
         ));
 
-        $builder->add('friday', 'choice', array(
+        $builder->add('friday', CheckboxType::class, array(
             'label' => 'Fredag',
-            'choices' => $workChoices,
-            'expanded' => true,
+            'required' => false,
         ));
     }
 

--- a/src/AppBundle/Form/Type/DaysType.php
+++ b/src/AppBundle/Form/Type/DaysType.php
@@ -12,7 +12,6 @@ class DaysType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-
         $builder->add('monday', CheckboxType::class, array(
             'label' => 'Mandag passer IKKE',
             'required' => false,

--- a/src/AppBundle/Tests/Controller/AdmissionControllerTest.php
+++ b/src/AppBundle/Tests/Controller/AdmissionControllerTest.php
@@ -95,11 +95,11 @@ class AdmissionControllerTest extends BaseWebTestCase
         $form = $submitButton->form();
 
         $form['application[applicationPractical][yearOfStudy]'] = 3;
-        $form['application[applicationPractical][days][monday]'] = 'Bra';
-        $form['application[applicationPractical][days][tuesday]'] = 'Ikke';
-        $form['application[applicationPractical][days][wednesday]'] = 'Bra';
-        $form['application[applicationPractical][days][thursday]'] = 'Ikke';
-        $form['application[applicationPractical][days][friday]'] = 'Bra';
+        $form['application[applicationPractical][days][monday]']->tick();
+        $form['application[applicationPractical][days][tuesday]']->untick();
+        $form['application[applicationPractical][days][wednesday]']->tick();
+        $form['application[applicationPractical][days][thursday]']->untick();
+        $form['application[applicationPractical][days][friday]']->tick();
         $form['application[applicationPractical][doublePosition]'] = 0;
         $form['application[applicationPractical][preferredGroup]'] = 'Bolk 1';
         $form['application[applicationPractical][language]'] = 'Engelsk';

--- a/src/AppBundle/Tests/Controller/InterviewControllerTest.php
+++ b/src/AppBundle/Tests/Controller/InterviewControllerTest.php
@@ -17,11 +17,11 @@ class InterviewControllerTest extends BaseWebTestCase
         $form = $crawler->selectButton('Lagre')->form();
 
         // Fill in the form
-        $form['application[applicationPractical][days][monday]']->select('Bra');
-        $form['application[applicationPractical][days][tuesday]']->select('Bra');
-        $form['application[applicationPractical][days][wednesday]']->select('Ikke');
-        $form['application[applicationPractical][days][thursday]']->select('Bra');
-        $form['application[applicationPractical][days][friday]']->select('Ikke');
+        $form['application[applicationPractical][days][monday]']->tick();
+        $form['application[applicationPractical][days][tuesday]']->tick();
+        $form['application[applicationPractical][days][wednesday]']->untick();
+        $form['application[applicationPractical][days][thursday]']->tick();
+        $form['application[applicationPractical][days][friday]']->untick();
 
         $form['application[applicationPractical][doublePosition]']->select('1');
         $form['application[applicationPractical][preferredGroup]']->select('Bolk 1');
@@ -50,11 +50,11 @@ class InterviewControllerTest extends BaseWebTestCase
         $form = $crawler->selectButton('Lagre')->form();
 
         // Fill in the form
-        $form['application[applicationPractical][days][monday]']->select('Bra');
-        $form['application[applicationPractical][days][tuesday]']->select('Bra');
-        $form['application[applicationPractical][days][wednesday]']->select('Ikke');
-        $form['application[applicationPractical][days][thursday]']->select('Bra');
-        $form['application[applicationPractical][days][friday]']->select('Ikke');
+        $form['application[applicationPractical][days][monday]']->tick();
+        $form['application[applicationPractical][days][tuesday]']->tick();
+        $form['application[applicationPractical][days][wednesday]']->untick();
+        $form['application[applicationPractical][days][thursday]']->tick();
+        $form['application[applicationPractical][days][friday]']->untick();
 
         $form['application[applicationPractical][doublePosition]']->select('1');
         $form['application[applicationPractical][preferredGroup]']->select('Bolk 1');

--- a/src/AppBundle/Tests/Controller/InterviewControllerTest.php
+++ b/src/AppBundle/Tests/Controller/InterviewControllerTest.php
@@ -76,8 +76,8 @@ class InterviewControllerTest extends BaseWebTestCase
     private function verifyInterview($crawler)
     {
         $this->assertEquals(2, $crawler->filter('p:contains("Test answer")')->count());
-        $this->assertEquals(3, $crawler->filter('td:contains("Bra")')->count());
-        $this->assertEquals(2, $crawler->filter('td:contains("Ikke")')->count());
+        $this->assertEquals(2, $crawler->filter('td:contains("Bra")')->count());
+        $this->assertEquals(3, $crawler->filter('td:contains("Ikke")')->count());
         $this->assertGreaterThan(0, $crawler->filter('td:contains("5")')->count());
         $this->assertGreaterThan(0, $crawler->filter('td:contains("4")')->count());
         $this->assertGreaterThan(0, $crawler->filter('td:contains("6")')->count());


### PR DESCRIPTION
resolves #601 

Hver $dag i søknaden har blitt endret fra string til boolean.
True: Dagen passer
False: Dagen passer ikke
I den praktiske delen av intervjuet formulerer vi spørsmålet slik: "Hvilke dager passer IKKE?"
Derfor huker man av hvilke dager som ikke passer. Denne delen av skjemaet mappes tilbake til søknaden på denne måten:
Checkboks valgt: $dag = false
Checkboks ikke valgt: $dag = true

### Under intervju
![image](https://user-images.githubusercontent.com/6677078/35436081-59392862-028d-11e8-8cbe-a29bc6d7505b.png)

### Etter intervju
![image](https://user-images.githubusercontent.com/6677078/35436116-714485a0-028d-11e8-9f4d-2bf13bf60a40.png)

## TODO
- [x] Flytt checkboksene slik at de står før label ELLER Aligne checkboksene
- [x] Sjekk at database migrasjonen er riktig
- [x] Oppdatere AssistantScheduling

