### PR TITLE
Run dev server on any ip

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "setup:win": "php .\\composer.phar install -n && npm install && npm run setup:scheduling:win && npm run build:dev  && php app/console doctrine:schema:drop --force --env=dev && php app/console doctrine:schema:create --env=dev && php app/console doctrine:fixtures:load --env=dev -n",
     "setup:scheduling": "cd src/AppBundle/AssistantScheduling/Webapp && npm install",
     "setup:scheduling:win": "cd src\\AppBundle\\AssistantScheduling\\Webapp && npm install",
-    "start": "concurrently --kill-others \"php app/console server:run --docroot=www\" \"npm run watch\"",
+    "start": "concurrently --kill-others \"php app/console server:run --docroot=www 0.0.0.0:8000\" \"npm run watch\"",
     "watch": "gulp",
     "watch:scheduling": "gulp watch:scheduling",
     "db:reload": "php app/console doctrine:fixtures:load -n --env=dev",


### PR DESCRIPTION
Ved å legge til `0.0.0.0:8000` i startscriptet kan man nå åpne dev-siden med andre iper enn `127.0.0.1`. F.eks hvis man vil åpne den på mobil. 