### PR TITLE
Only send admission notifications if subscribed less than one year ago

### DIFF
--- a/src/AppBundle/Service/AdmissionNotifier.php
+++ b/src/AppBundle/Service/AdmissionNotifier.php
@@ -76,7 +76,8 @@ class AdmissionNotifier
                     }
                     $hasApplied = array_search($subscriber->getEmail(), $applicationEmails) !== false;
                     $alreadyNotified = array_search($subscriber->getEmail(), $notificationEmails) !== false;
-                    if ($hasApplied || $alreadyNotified) {
+                    $subscribedMoreThanOneYearAgo = $subscriber->getTimestamp()->diff(new \DateTime())->y >= 1;
+                    if ($hasApplied || $alreadyNotified || $subscribedMoreThanOneYearAgo) {
                         continue;
                     }
 
@@ -86,6 +87,8 @@ class AdmissionNotifier
                     $notification->setSubscriber($subscriber);
                     $this->em->persist($notification);
                     $notificationsSent++;
+
+                    usleep(50 * 1000); // 50ms
                 }
                 if ($notificationsSent > 0) {
                     $this->logger->info("*$notificationsSent* admission notification emails sent to subscribers in *" . $department->getCity() . "*");


### PR DESCRIPTION
Listen med admission subscribers kommer til å vokse fort (flere hundre hvert år), noe som kan skape litt trøbbel mtp. sending limits fra gsuite. Ved å sette en grense for når en subscription blir "utdatert" (f.eks. 1 år) begrenses antallet i listen som skal motta e-post. Ved å sette grensen til 1 år vil en subscriber få en notification de neste 2 opptaksperiodene.

Er det nyttig for subsribers å fortsatt motta notifications etter 1 år? Er det sannsynlig at de kommer til å søke som assistent etter 1 år hvis de ikke allerede gjorde det i løpet av de 2 første opptaksperiodene?