### PR TITLE
Update symfony to version 2.8.44

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "symfony/symfony": "2.8.*",
+        "symfony/symfony": "2.8.*,>=2.8.44",
         "doctrine/orm": "~2.2",
         "doctrine/dbal": "<2.5",
         "doctrine/doctrine-bundle": "~1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c473850c0fc4d8dfe6d2b11dc714f61f",
+    "content-hash": "cfd93b1b9c0f4a2d469f66bc843ffe65",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -4327,16 +4327,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.10",
+            "version": "v5.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "dd71cc1638ed7aebbb33f2e2b0edd2cf6ea73d97"
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/dd71cc1638ed7aebbb33f2e2b0edd2cf6ea73d97",
-                "reference": "dd71cc1638ed7aebbb33f2e2b0edd2cf6ea73d97",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
                 "shasum": ""
             },
             "require": {
@@ -4377,7 +4377,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2018-07-27T08:58:59+00:00"
+            "time": "2018-07-31T09:26:32+00:00"
         },
         {
             "name": "symfony/assetic-bundle",
@@ -5141,16 +5141,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.8.43",
+            "version": "v2.8.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "e7f50768f107fa951f4c80dc447b893502cf2e89"
+                "reference": "789dc7eb57579185a430e65c5efce4b2d6b6b7b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/e7f50768f107fa951f4c80dc447b893502cf2e89",
-                "reference": "e7f50768f107fa951f4c80dc447b893502cf2e89",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/789dc7eb57579185a430e65c5efce4b2d6b6b7b1",
+                "reference": "789dc7eb57579185a430e65c5efce4b2d6b6b7b1",
                 "shasum": ""
             },
             "require": {
@@ -5277,7 +5277,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2018-07-23T09:03:03+00:00"
+            "time": "2018-08-01T14:12:49+00:00"
         },
         {
             "name": "tfox/mpdf-port-bundle",


### PR DESCRIPTION
Oppdaterer symfony til `2.8.44` pga [https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers](https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers)