### PR TITLE
Don't show specific department in CTA if it's determined by geolocation

### DIFF
--- a/app/Resources/views/assistant/assistants.html.twig
+++ b/app/Resources/views/assistant/assistants.html.twig
@@ -17,7 +17,7 @@
         {% if departmentsWithActiveAdmission is not empty %}
             <div class="content text-center call-to-action jumbotron">
                 <i class="fa fa-info-circle alert-icon text-dark-blue"></i>
-                {% if specific_department in departmentsWithActiveAdmission %}
+                {% if department_in_url and specific_department in departmentsWithActiveAdmission %}
                     <p class="text-dark-blue">
                         Avdeling
                         <span class="active-admission-departments">

--- a/src/AppBundle/Controller/AssistantController.php
+++ b/src/AppBundle/Controller/AssistantController.php
@@ -93,8 +93,10 @@ class AssistantController extends Controller
         $departments = $this->get('app.geolocation')->sortDepartmentsByDistanceFromClient($departments);
         $departmentsWithActiveAdmission = $this->get('app.filter_service')->filterDepartmentsByActiveAdmission($departments, true);
 
+        $departmentInUrl = true;
         if (null === $specificDepartment) {
             $specificDepartment = $departments[0];
+            $departmentInUrl = false;
         }
 
         $teams = $em->getRepository('AppBundle:Team')->findByOpenApplicationAndDepartment($specificDepartment);
@@ -140,6 +142,7 @@ class AssistantController extends Controller
 
         return $this->render('assistant/assistants.html.twig', array(
             'specific_department' => $specificDepartment,
+            'department_in_url' => $departmentInUrl,
             'departments' => $departments,
             'departmentsWithActiveAdmission' => $departmentsWithActiveAdmission,
             'teams' => $teams,

--- a/src/AppBundle/Controller/AssistantController.php
+++ b/src/AppBundle/Controller/AssistantController.php
@@ -93,10 +93,9 @@ class AssistantController extends Controller
         $departments = $this->get('app.geolocation')->sortDepartmentsByDistanceFromClient($departments);
         $departmentsWithActiveAdmission = $this->get('app.filter_service')->filterDepartmentsByActiveAdmission($departments, true);
 
-        $departmentInUrl = true;
-        if (null === $specificDepartment) {
+        $departmentInUrl = $specificDepartment !== null;
+        if (!$departmentInUrl) {
             $specificDepartment = $departments[0];
-            $departmentInUrl = false;
         }
 
         $teams = $em->getRepository('AppBundle:Team')->findByOpenApplicationAndDepartment($specificDepartment);


### PR DESCRIPTION
Selv om department ikke var gitt for `/opptak` og lignende, settes jo `specific_department` til den nærmest brukerens lokasjon. Med denne PRen fungerer det som det skal, altså at `/opptak` og `/assistenter` viser denne CTAen:
![image](https://user-images.githubusercontent.com/5937246/44102274-994dc4c2-9fe9-11e8-9cc5-d8ed8e63d14c.png)
i mens `/opptak/Trondheim` og lignende viser denne:
![image](https://user-images.githubusercontent.com/5937246/44102320-b0d4643e-9fe9-11e8-87f0-5e466a39c649.png)
