### PR TITLE
Update application status for existing assistants

### DIFF
--- a/app/Resources/views/my_page/my_page.html.twig
+++ b/app/Resources/views/my_page/my_page.html.twig
@@ -20,6 +20,8 @@
                     <div class="col-12 col-lg-6 mb-3 mb-lg-0">
                         {% include 'my_page/my_partners.html.twig' with {application: active_application} %}
                     </div>
+                {% elseif app.user.hasBeenAssistant %}
+                    <div class="col-lg-3"></div>
                 {% elseif not active_application.interview %}
                     <div class="col-lg-3"></div>
                 {% elseif active_application.interview.interviewed %}

--- a/src/AppBundle/Service/ApplicationManager.php
+++ b/src/AppBundle/Service/ApplicationManager.php
@@ -17,17 +17,24 @@ class ApplicationManager
     public function getApplicationStatus(Application $application): ApplicationStatus
     {
         $interview = $application->getInterview();
-        if ($interview === null) {
-            return new ApplicationStatus(
-                ApplicationStatus::APPLICATION_RECEIVED,
-                "Søknad mottatt",
-                "Vent på å bli invitert til intervju"
-            );
-        } elseif ($application->getUser()->isActiveAssistant()) {
+        $user = $application->getUser();
+        if ($application->getUser()->isActiveAssistant()) {
             return new ApplicationStatus(
                 ApplicationStatus::ASSIGNED_TO_SCHOOL,
                 "Tatt opp som vektorassistent",
                 "Ta kontakt med dine vektorpartnere og dra ut til skolen"
+            );
+        } elseif ($user->hasBeenAssistant()) {
+            return new ApplicationStatus(
+                ApplicationStatus::INTERVIEW_COMPLETED,
+                "Søknad mottatt",
+                "Siden du har vært assistent tidligere trenger du ikke å møte på intervju. Du vil få en e-post når opptaket er klart."
+            );
+        } elseif ($interview === null) {
+            return new ApplicationStatus(
+                ApplicationStatus::APPLICATION_RECEIVED,
+                "Søknad mottatt",
+                "Vent på å bli invitert til intervju"
             );
         } elseif ($interview->getInterviewed()) {
             return new ApplicationStatus(


### PR DESCRIPTION
Brukere som har vært assistent tidligere skal ikke intervjues på nytt. Status på søknaden vil derfor gå direkte til:

![image](https://user-images.githubusercontent.com/6992505/44160698-7bbb4880-a0bb-11e8-81f7-7cae63ab99a7.png)
