### PR TITLE
Ensure user is logged in before accessing /profil/partnere

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -140,6 +140,7 @@ security:
 
           #ROLE_USER = assistant user
         - { path: ^/profil/rediger, roles: ROLE_USER }
+        - { path: ^/profil/partnere, roles: ROLE_USER }
         - { path: ^/profile$, roles: ROLE_USER }
         - { path: ^/utlegg, roles: ROLE_USER }
         - { path: ^/api/myreceipts, roles: ROLE_USER }


### PR DESCRIPTION
Å gå til /profil/partnere krever at brukeren er logget inn ellers vil 
```
 if (!$this->getUser()->isActive()) {
    throw $this->createAccessDeniedException();
}
```
gi en error. 