### PR TITLE
Ikke send brukerdata i kvittering fra kontaktskjema

### DIFF
--- a/app/Resources/views/admission/receiptEmail.txt.twig
+++ b/app/Resources/views/admission/receiptEmail.txt.twig
@@ -1,3 +1,7 @@
-Hei {{ contact.name }}, henvendelsen din sendt gjennom kontaktskjema på vektorprogrammet.no ble mottatt den {{ "now" | date("Y-m-d H:i") }}.
+Hei,
+
+Henvendelsen din sendt gjennom kontaktskjema på vektorprogrammet.no ble mottatt den {{ "now" | date("Y-m-d H:i") }}.
 
 Vi sender deg svar innen kort tid.
+
+Mvh. Vektorprogrammet


### PR DESCRIPTION
Siden vi ikke har noen måte å verifisere at den oppgitte mailadressen faktisk tilhører avsenderen, burde vi ikke sende med _noe_ user input i kvitteringen. Dette forhindrer at folk kan forfalske mailer sendt fra @vektorprogrammet adresser eller gjøre XSS. 