### PR TITLE
Set drive permission of teams to 'fileOrganizer' instead of 'owner'

### DIFF
--- a/src/AppBundle/Google/GoogleDrive.php
+++ b/src/AppBundle/Google/GoogleDrive.php
@@ -31,7 +31,7 @@ class GoogleDrive extends GoogleService
 
         $permission = new \Google_Service_Drive_Permission();
         $permission->setType('group');
-        $permission->setRole('owner');
+        $permission->setRole('fileOrganizer');
         $permission->setEmailAddress($team->getEmail());
 
         try {


### PR DESCRIPTION
Fixes #1078 

Tidligere har vi satt teamet til å bli 'owner' av team-driven sin for å gi medlemmene mulighet til å slette filer. Nå har det kommet en ny rolle som heter `fileOrganizer` som gir medlemmene mulighet til å legge filer i papirkurven (men ikke slette permanent). 

Samtidig som denne nye rollen har blitt introdusert ser det ut til at det nå kreves at vi sender med et ekstra felt, `'transferOwnership' => 'true'`, nå man overfører eierskap. Dette fører til at vi får feilmelding når vi prøver å gjøre teamet til 'owner', siden vi ikke har med `transferOwnership`-feltet.

Forslag er derfor å gi teamene 'fileOrganizer'-rolle i stedet for 'owner'.

![image](https://user-images.githubusercontent.com/6992505/48135190-745fa180-e29c-11e8-8638-1a2159078305.png)
