### PR TITLE
Nerf admission notifications

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,7 +27,7 @@ parameters:
     max_length: 1200
     country_code: '47'
 
-  daily_admission_notifier_limit: 666
+  admission_notifier_limit: 100
 
   # File upload parameters
   public_uploads: "Offentlige filer"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -19,7 +19,7 @@ services:
 
     AppBundle\Service\AdmissionNotifier:
         arguments:
-            $sendLimit: '%daily_admission_notifier_limit%'
+            $sendLimit: '%admission_notifier_limit%'
 
     guzzle.slack:
         class: GuzzleHttp\Client

--- a/src/AppBundle/Service/AdmissionNotifier.php
+++ b/src/AppBundle/Service/AdmissionNotifier.php
@@ -6,6 +6,7 @@ namespace AppBundle\Service;
 use AppBundle\Entity\AdmissionNotification;
 use AppBundle\Entity\AdmissionSubscriber;
 use AppBundle\Entity\Department;
+use AppBundle\Entity\Semester;
 use Doctrine\ORM\EntityManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -83,12 +84,7 @@ class AdmissionNotifier
                         continue;
                     }
 
-                    $this->emailSender->sendAdmissionStartedNotification($subscriber);
-                    $notification = new AdmissionNotification();
-                    $notification->setSemester($semester);
-                    $notification->setDepartment($department);
-                    $notification->setSubscriber($subscriber);
-                    $this->em->persist($notification);
+                    $this->sendAdmissionNotification($subscriber, $semester, $department);
                     $notificationsSent++;
                 }
                 if ($notificationsSent > 0) {
@@ -97,9 +93,26 @@ class AdmissionNotifier
             }
         } catch (\Exception $e) {
             $this->logger->critical("Failed to send admission notification:\n".$e->getMessage());
-        } finally {
-            $this->em->flush();
         }
+    }
+
+    /**
+     * @param AdmissionSubscriber $subscriber
+     * @param Semester $semester
+     * @param Department $department
+     *
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    private function sendAdmissionNotification(AdmissionSubscriber $subscriber, Semester $semester, Department $department)
+    {
+        $this->emailSender->sendAdmissionStartedNotification($subscriber);
+        $notification = new AdmissionNotification();
+        $notification->setSemester($semester);
+        $notification->setDepartment($department);
+        $notification->setSubscriber($subscriber);
+        $this->em->persist($notification);
+        $this->em->flush();
     }
 
     public function sendInfoMeetingNotifications()
@@ -134,13 +147,7 @@ class AdmissionNotifier
                     if ($hasApplied || $alreadyNotified || $subscribedMoreThanOneYearAgo || !$subscriber->getInfoMeeting()) {
                         continue;
                     }
-                    $this->emailSender->sendInfoMeetingNotification($subscriber);
-                    $notification = new AdmissionNotification();
-                    $notification->setSemester($semester);
-                    $notification->setDepartment($department);
-                    $notification->setSubscriber($subscriber);
-                    $notification->setInfoMeeting(true);
-                    $this->em->persist($notification);
+                    $this->sendInfoMeetingNotification($subscriber, $semester, $department);
                     $notificationsSent++;
                 }
                 if ($notificationsSent > 0) {
@@ -149,8 +156,26 @@ class AdmissionNotifier
             }
         } catch (\Exception $e) {
             $this->logger->critical("Failed to send info meeting notification:\n".$e->getMessage());
-        } finally {
-            $this->em->flush();
         }
+    }
+
+    /**
+     * @param AdmissionSubscriber $subscriber
+     * @param Semester $semester
+     * @param Department $department
+     *
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    private function sendInfoMeetingNotification(AdmissionSubscriber $subscriber, Semester $semester, Department $department)
+    {
+        $this->emailSender->sendInfoMeetingNotification($subscriber);
+        $notification = new AdmissionNotification();
+        $notification->setSemester($semester);
+        $notification->setDepartment($department);
+        $notification->setSubscriber($subscriber);
+        $notification->setInfoMeeting(true);
+        $this->em->persist($notification);
+        $this->em->flush();
     }
 }

--- a/src/AppBundle/Service/AdmissionNotifier.php
+++ b/src/AppBundle/Service/AdmissionNotifier.php
@@ -74,7 +74,7 @@ class AdmissionNotifier
 
                 $notificationsSent = 0;
                 foreach ($subscribers as $subscriber) {
-                    if ($notificationsSent > $this->sendLimit) {
+                    if ($notificationsSent >= $this->sendLimit) {
                         break;
                     }
                     $hasApplied = array_search($subscriber->getEmail(), $applicationEmails) !== false;
@@ -138,7 +138,7 @@ class AdmissionNotifier
 
                 $notificationsSent = 0;
                 foreach ($subscribers as $subscriber) {
-                    if ($notificationsSent > $this->sendLimit) {
+                    if ($notificationsSent >= $this->sendLimit) {
                         break;
                     }
                     $hasApplied = array_search($subscriber->getEmail(), $applicationEmails) !== false;


### PR DESCRIPTION
### This PR attempts to make admission notification sending safer
* Send max 100 admission notifications at a time
* Flush DB after each notification is sent to ensure notifications are never sent twice
* Refactor send logic into separate function for simplicity