### PR TITLE
Fix warning in npm debug log

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true

--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true


### PR DESCRIPTION
Fix the following npm warning
```
warn lifecycle npm is using /usr/bin/node but there is no node binary in the current PATH. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```