### PR TITLE
Build client with production config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,7 @@ date >>$log
 git checkout . >>$log 2>&1
 git pull origin master >>$log 2>&1
 SYMFONY_ENV=prod php ./composer.phar install --no-dev --optimize-autoloader >>$log 2>&1
+export NODE_ENV=production
 npm install >>$log 2>&1
 ./node_modules/.bin/gulp build:prod >>$log 2>&1
 npm run setup:client >>$log 2>&1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,15 +153,6 @@ function clientStaticFiles () {
     .pipe(gulp.dest('web/js/client'));
 }
 
-function clientStaticFilesProd () {
-  var r = gulp.src(path.client.src + '/dist/js/**/*.js')
-    .pipe(concat('app.js'))
-    .pipe(gulp.dest('web/js/client'));
-  return r && gulp.src(path.client.src + '/dist/css/**/*.css')
-    .pipe(concat('app.css'))
-    .pipe(gulp.dest('web/css/client'));
-}
-
 gulp.task('frontEnd', function () {
   gulp.src(path.frontEnd + '/**/*')
       .pipe(gulp.dest('web/'));
@@ -180,5 +171,5 @@ function watch () {
 gulp.task('build:prod', gulp.parallel([stylesProd, scriptsProd, imagesProd, files, icons, vendor]));
 gulp.task('build:dev', gulp.parallel([stylesDev, scriptsDev, imagesDev, files, icons, vendor]));
 gulp.task('default', gulp.series(['build:dev', watch]));
-gulp.task('build:client', gulp.series([buildClientApp, clientStaticFilesProd]));
+gulp.task('build:client', gulp.series([buildClientApp, clientStaticFiles]));
 gulp.task('build:scheduling', gulp.series([assistantSchedulingStaticFiles]));


### PR DESCRIPTION
> ### :heavy_check_mark: Fikser at staging ikke bygger client skikkelig
> ### :question: Fikser error under byggingen av client i prod deploy

## Problemet
I staging er flagget `NODE_ENV` satt til `staging`. I prod derimot er ikke dette flagget satt. Dermed bygges det statiske filer for ment for dev. Eksempel:
![image](https://user-images.githubusercontent.com/5937246/51790233-86adf500-2192-11e9-80ab-f2884bb38f91.png)
Når `NODE_ENV` er `production` eller `staging` bygges en enkel `app.js`. 