### PR TITLE
Hotfix: Replace tomorrow with today in info meeting mail

### DIFF
--- a/app/Resources/views/admission/info_meeting_email.html.twig
+++ b/app/Resources/views/admission/info_meeting_email.html.twig
@@ -1,7 +1,7 @@
-<h1>Infomøte med Vektorprogrammet i morgen!</h1>
+<h1>Infomøte med Vektorprogrammet i dag!</h1>
 
 <br>
-<p>I morgen har vi infomøte kl. {{ infoMeeting.date|date('H:i') }}
+<p>I dag har vi infomøte kl. {{ infoMeeting.date|date('H:i') }}
 {% if infoMeeting.room %}
 i rom {{ infoMeeting.room }}
 {% endif %}!</p>

--- a/src/AppBundle/Service/EmailSender.php
+++ b/src/AppBundle/Service/EmailSender.php
@@ -112,7 +112,7 @@ class EmailSender
     public function sendInfoMeetingNotification(AdmissionSubscriber $subscriber)
     {
         $message = (new \Swift_Message())
-            ->setSubject('Infomøte i morgen!')
+            ->setSubject('Infomøte i dag!')
             ->setFrom($this->defaultEmail)
             ->setTo($subscriber->getEmail())
             ->setBody($this->twig->render('admission/info_meeting_email.html.twig', array(


### PR DESCRIPTION
Quick fix som bytter ut "Infomøte i morgen" med "Infomøte i dag". Lager en ny PR senere som regner ut i morgen/i dag ut i fra datoene. 