### PR TITLE
Add comment saying the receipt sum must match the outlay sum

### DIFF
--- a/app/Resources/views/receipt/create_receipt.html.twig
+++ b/app/Resources/views/receipt/create_receipt.html.twig
@@ -3,6 +3,10 @@
         <div class="col-12 col-sm-6">
             {{ form_row(form.description) }}
             {{ form_row(form.sum) }}
+            <p class="mt-0 mb-3">
+                <span class="font-weight-bold">Merk:</span>
+                Summen må stemme nøyaktig med den på kvitteringen.
+            </p>
             {{ form_row(form.receiptDate) }}
 
             {% include 'receipt/account_number.html.twig' %}


### PR DESCRIPTION
Dette gjøres for å forhindre at folk runder opp eller ned i utleggene, som skaper krøll i budsjettet. (Det må stemme på øret)
![image](https://user-images.githubusercontent.com/5937246/52234138-3be25a80-28c1-11e9-967d-97336a4def04.png)
