### PR TITLE
Fjern padding i "table only cards"

### DIFF
--- a/app/Resources/assets/scss/control_panel.scss
+++ b/app/Resources/assets/scss/control_panel.scss
@@ -28,6 +28,10 @@ body {
   }
 }
 
+.main .container-fluid {
+  padding: 0 15px;
+}
+
 .dropdown-item, .btn {
   font-size: 14px;
 }
@@ -864,4 +868,12 @@ button.secretly-not-a-button {
   &:focus{
     box-shadow: none;
   }
+}
+
+.vertical-middle {
+  vertical-align: middle;
+}
+
+table.table {
+  margin-bottom: 0;
 }

--- a/app/Resources/assets/scss/pages/assistants.scss
+++ b/app/Resources/assets/scss/pages/assistants.scss
@@ -92,7 +92,7 @@
     padding:27px;
     @media (min-width: 768px) {
       padding:35px;
-      margin-top:-60px;
+      margin-top:40px;
     }
     p {
       @media (max-width: 400px) {

--- a/app/Resources/views/admin/access_rule/index.html.twig
+++ b/app/Resources/views/admin/access_rule/index.html.twig
@@ -23,7 +23,7 @@
             <div class="col-12 col-xxxl-6 order-last order-xxxl-first">
                 <div class="card">
                     <div class="card-header"><i class="fa fa-shield-alt"></i> Routing Rules</div>
-                    <div class="card-body table-responsive">
+                    <div class="table-responsive">
                         {% include 'admin/access_rule/access_rule_table.html.twig' with {rules: routingRules} %}
                     </div>
                 </div>
@@ -34,7 +34,7 @@
             <div class="col-12 col-xxxl-6 order-first order-xxxl-last">
                 <div class="card">
                     <div class="card-header"><i class="fa fa-shield-alt"></i> Custom Rules</div>
-                    <div class="card-body table-responsive">
+                    <div class="table-responsive">
                         {% include 'admin/access_rule/access_rule_table.html.twig' with {rules: customRules} %}
                     </div>
                 </div>

--- a/app/Resources/views/admission_admin/application.html.twig
+++ b/app/Resources/views/admission_admin/application.html.twig
@@ -15,13 +15,13 @@
         <div class="col-12 col-lg-6">
             <div class="card">
                 <div class="card-header"><i class="fa fa-user-o"></i> Søker {{ user }}</div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     {% include 'interview/interviewee_table.html.twig' %}
                 </div>
             </div>
             <div class="card">
                 <div class="card-header"><i class="fa fa-calendar-check-o"></i> Tilgjengelige dager</div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     <table class="table table-bordered">
                         <tr>
                             <td><b>Mandag</b></td>
@@ -50,7 +50,7 @@
         <div class="col-12 col-lg-6">
             <div class="card">
                 <div class="card-header"><i class="fa fa-align-justify"></i> Søknad</div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     <table class="table table-bordered">
                         <tr>
                             <td><b>Kjønn</b></td>

--- a/app/Resources/views/admission_admin/assigned_applications/interview_distribution.html.twig
+++ b/app/Resources/views/admission_admin/assigned_applications/interview_distribution.html.twig
@@ -3,7 +3,7 @@
         <div class="card-header">
             <i class="fa fa-align-justify"></i> Intervjufordeling
         </div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
             <table id="interview-distribution-table" width="100%" class="table">
                 <thead>
                 <tr class="text-center">

--- a/app/Resources/views/admission_admin/assigned_table.html.twig
+++ b/app/Resources/views/admission_admin/assigned_table.html.twig
@@ -2,7 +2,7 @@
     <div class="card-header">
         <i class="fa fa-align-justify"></i> {{ title }}
     </div>
-    <div class="card-body table-responsive">
+    <div class="table-responsive">
         <table width="100%" class="application-table table table-striped">
 
             <thead>
@@ -23,7 +23,7 @@
             {% for a in applicants %}
                 {% set has_access_to_interview = is_granted_team_leader() or a.interview.isInterviewer(app.user) or a.interview.isCoInterviewer(app.user) %}
             <tr>
-                <td>
+                <td class="table-menu">
                     {% if has_access_to_interview %}
                     <div class="dropdown">
                         <div class="clickable px-2" id="options-{{ a.id }}" data-toggle="dropdown"

--- a/app/Resources/views/admission_admin/existing_assistants_applications_table.html.twig
+++ b/app/Resources/views/admission_admin/existing_assistants_applications_table.html.twig
@@ -12,7 +12,7 @@
         <div class="card-header">
             <i class="fa fa-align-justify"></i> Tidligere assistenter ({{ applications|length }})
         </div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
 
             <table width="100%" class="application-table table table-striped">
                 <thead>
@@ -36,7 +36,7 @@
                 {% for a in applications %}
                     <tr>
                         {% if is_granted_team_leader() %}
-                            <td>
+                            <td class="table-menu">
                                 <div class="dropdown">
                                     <div class="clickable px-2" id="options-{{ a.id }}" data-toggle="dropdown"
                                          aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/admission_admin/interviewed_applications_table.html.twig
+++ b/app/Resources/views/admission_admin/interviewed_applications_table.html.twig
@@ -10,7 +10,7 @@
 {% block applications %}
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Intervjuer ({{ applications|length }})</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
             <table width="100%" class="application-table table table-striped">
                 <thead>
                 <tr>
@@ -36,7 +36,7 @@
                     {% set userCanSeeInterview = a.user != app.user and ( is_granted_team_leader() or a.interview.interviewer == app.user or a.interview.coInterviewer == app.user ) %}
                     <tr>
                         {% if is_granted_team_leader() %}
-                            <td>
+                            <td class="table-menu">
                                 <div class="dropdown">
                                     <div class="clickable px-2" id="options-{{ a.id }}" data-toggle="dropdown"
                                          aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/admission_admin/new_applications/table.html.twig
+++ b/app/Resources/views/admission_admin/new_applications/table.html.twig
@@ -1,7 +1,7 @@
 <form id="bulk" name="interview">
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Nye søkere ({{ applications|length }})</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
 
 
             <table width="100%" class="application-table table table-striped">

--- a/app/Resources/views/admission_admin/teamInterest.html.twig
+++ b/app/Resources/views/admission_admin/teamInterest.html.twig
@@ -30,7 +30,7 @@
     <h2 class="text-center my-5">Teaminteresse {{ department.shortname }} {{ semester.semestertime }} {{ semester.year }}</h2>
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Team med interessenter</div>
-        <div class="card-body">
+        <div class="table-responsive">
             <table width="100%" class="team-table table">
                 <thead>
                 <tr>
@@ -80,7 +80,7 @@
             <h4>Fra intervju</h4>
             <p>Disse svarte ja på interesse for team under intervju for å bli vektorassistent</p>
         </div>
-        <div class="card-body">
+        <div class="table-responsive">
             <table class="table">
                 <thead>
                 <tr>
@@ -130,7 +130,7 @@
                 </a>
             </p>
         </div>
-        <div class="card-body">
+        <div class="table-responsive">
             <table class="table">
                 <thead>
                 <tr>

--- a/app/Resources/views/admission_period_admin/index.html.twig
+++ b/app/Resources/views/admission_period_admin/index.html.twig
@@ -38,7 +38,7 @@
                 <div class="card-header">
                     <i class="fa fa-align-justify"></i> Opptaksperioder {{ department }}
                 </div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     <table class="table">
 
                         <thead>
@@ -56,7 +56,7 @@
                         {% for a in admissionPeriods %}
                             <tr class="text-nowrap">
                                 {% if is_granted_team_leader() %}
-                                    <td>
+                                    <td class="table-menu">
                                         <div class="dropdown">
                                             <div class="clickable" id="options-{{ a.id }}" data-toggle="dropdown"
                                                  aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/article_admin/index.html.twig
+++ b/app/Resources/views/article_admin/index.html.twig
@@ -20,7 +20,7 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-header"><i class="fa fa-align-justify"></i> Artikler ({{ articles|length }})</div>
-                <div class="card-body">
+                <div class="table-responsive">
                     <table class="table" id="article-table">
                         <thead>
                         <tr>
@@ -35,7 +35,7 @@
                         <tbody>
                         {% for a in pagination %}
                             <tr id="{{ a.id }}">
-                                <td>
+                                <td class="table-menu">
                                     <div class="dropdown">
                                         <div class="clickable px-2" id="options-{{ a.id }}" data-toggle="dropdown"
                                              aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/assistant/assistants.html.twig
+++ b/app/Resources/views/assistant/assistants.html.twig
@@ -7,7 +7,7 @@
 {% block body %}
     <div class="container-fluid assistants">
         <div class="content">
-            <header class="row page-header">
+            <header class="row page-header mb-0">
                 <div class="col-12">
                     {% include 'statictext/static_content.html.twig' with {'id': 'assistants-header'} %}
                 </div>

--- a/app/Resources/views/certificate/index.html.twig
+++ b/app/Resources/views/certificate/index.html.twig
@@ -34,8 +34,8 @@
         <div class="col-12 col-xl-6">
             <div class="card">
                 <div class="card-header"><i class="fa fa-align-justify"></i> Assistenter {{ currentSemester.name }}</div>
-                <div class="card-body table-responsive">
-                    <table class="table" id="substitute-table">
+                <div class="table-responsive">
+                    <table class="table table-striped" id="substitute-table">
                         <thead>
                         <tr>
                             <th>Navn</th>

--- a/app/Resources/views/control_panel/index.html.twig
+++ b/app/Resources/views/control_panel/index.html.twig
@@ -22,14 +22,14 @@
         </div>
 
         <div class="row">
-            {% if admissionPeriod.hasActiveAdmission %}
+            {% if admissionPeriod and admissionPeriod.hasActiveAdmission %}
                 {{ render(controller("AppBundle:Widget:applicationGraph")) }}
             {% endif %}
 
             {{ render(controller("AppBundle:Widget:interviews")) }}
             {{ render(controller("AppBundle:Widget:receipts")) }}
 
-            {% if not admissionPeriod.hasActiveAdmission %}
+            {% if not admissionPeriod or not admissionPeriod.hasActiveAdmission %}
                 {{ render(controller("AppBundle:Widget:applicationGraph")) }}
             {% endif %}
         </div>

--- a/app/Resources/views/department_admin/index.html.twig
+++ b/app/Resources/views/department_admin/index.html.twig
@@ -21,7 +21,7 @@
 {% block body %}
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Avdelinger</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
             <table class="table" id="table">
                 <thead>
                 <tr>
@@ -35,7 +35,7 @@
                 <tbody>
                 {% for d in get_departments() %}
                     <tr>
-                        <td>
+                        <td class="table-menu">
                             <div class="dropdown">
                                 <div class="clickable px-2" id="options-{{ loop.index }}" data-toggle="dropdown"
                                      aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/executive_board/index.html.twig
+++ b/app/Resources/views/executive_board/index.html.twig
@@ -53,12 +53,12 @@
     <div class="row">
         <div class="col-12">
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade table-responsive show active" id="active" role="tabpanel" aria-labelledby="active-tab">
-                    <button class="btn btn-outline-secondary csv_download_button mb-3" data-table-id="activeMemberTable"><i class="fa fa-download"></i> Last ned CSV</button>
+                <div class="tab-pane fade table-responsive show active p-0" id="active" role="tabpanel" aria-labelledby="active-tab">
+                    <button class="btn btn-outline-secondary csv_download_button m-3" data-table-id="activeMemberTable"><i class="fa fa-download"></i> Last ned CSV</button>
                     {%  include(':executive_board:member_table.html.twig') with {'members': active_members, 'table_id': 'activeMemberTable'} %}
                 </div>
-                <div class="tab-pane fade table-responsive" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
-                    <button class="btn btn-outline-secondary csv_download_button mb-3" data-table-id="inactiveMemberTable"><i class="fa fa-download"></i> Last ned CSV</button>
+                <div class="tab-pane fade table-responsive p-0" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
+                    <button class="btn btn-outline-secondary csv_download_button m-3" data-table-id="inactiveMemberTable"><i class="fa fa-download"></i> Last ned CSV</button>
                     {%  include(':executive_board:member_table.html.twig') with {'members': inactive_members, 'table_id': 'inactiveMemberTable'} %}
                 </div>
             </div>

--- a/app/Resources/views/executive_board/member_table.html.twig
+++ b/app/Resources/views/executive_board/member_table.html.twig
@@ -14,7 +14,7 @@
     <tbody>
     {% for m in members %}
         <tr>
-            <td>
+            <td class="table-menu">
                 {% if is_granted_team_leader() %}
                     <div class="dropdown">
                         <div class="clickable px-2" id="options-{{ m.id }}" data-toggle="dropdown"

--- a/app/Resources/views/field_of_study/show_all.html.twig
+++ b/app/Resources/views/field_of_study/show_all.html.twig
@@ -18,7 +18,7 @@
                 <div class="card-header">
                     <i class="fa fa-align-justify"></i> Linjer {{ department }} ({{ fieldOfStudies|length }})
                 </div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     <table class="table">
                         <tr>
                             <th></th>

--- a/app/Resources/views/interview/conduct.html.twig
+++ b/app/Resources/views/interview/conduct.html.twig
@@ -33,7 +33,7 @@
                 <div class="card-header">
                     <span><i class="fa fa-comments-o"></i> Intervju - {{ application.user }}</span>
                 </div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     {% include 'interview/interviewee_table.html.twig' %}
                 </div>
             </div>

--- a/app/Resources/views/interview/schemas.html.twig
+++ b/app/Resources/views/interview/schemas.html.twig
@@ -21,7 +21,7 @@
         <div class="card-header">
             <i class="fa fa-comments-o"></i> Intervjuskjemaer
         </div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
             <table class="table">
                 <thead>
                 <tr>
@@ -32,7 +32,7 @@
                 <tbody>
                 {% for schema in schemas %}
                     <tr>
-                        <td width="50px">
+                        <td class="table-menu">
                             <div class="dropdown">
                                 <div class="clickable px-2" id="options-{{ loop.index }}" data-toggle="dropdown"
                                      aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/interview/show.html.twig
+++ b/app/Resources/views/interview/show.html.twig
@@ -22,7 +22,7 @@
         <div class="card-header">
             <span><i class="fa fa-comments-o"></i> Intervju - {{ application.user }} <small>{{ interview.conducted|date("d.m.y - G:i") }}</small></span>
         </div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
             {% include 'interview/interviewee_table.html.twig' %}
         </div>
     </div>

--- a/app/Resources/views/participant_history/index.html.twig
+++ b/app/Resources/views/participant_history/index.html.twig
@@ -52,8 +52,16 @@
 
 
 {% block body %}
-
-    <h2>Assistenter {{ department }} - {{ semester }}</h2>
+    <div class="row">
+        <div class="col-12 col-lg-6">
+            <h2>Assistenter {{ department }} - {{ semester }}</h2>
+        </div>
+        <div class="col-12 col-lg-6 text-right">
+            <button class="btn btn-outline-secondary csv_download_button" data-table-id="assistantTable"><i
+                        class="fa fa-download"></i> Last ned CSV
+            </button>
+        </div>
+    </div>
     <hr>
 
     <div class="row">
@@ -71,8 +79,8 @@
                         </div>
                     </div>
                 </div>
-                <div class="card-body table-responsive">
-                    <table width="100%" id="assistantTable" class="table">
+                <div class="table-responsive">
+                    <table width="100%" id="assistantTable" class="table table-striped">
 
                         <thead>
 
@@ -85,10 +93,6 @@
                             <th> Avdeling</th>
                             <th> Bolk</th>
                             <th> Dag</th>
-                            {% if is_granted_admin() or (is_granted_team_leader() and app.user.department == department) %}
-                                <th></th>
-                                <th></th>
-                            {% endif %}
                         </tr>
 
                         </thead>
@@ -96,7 +100,7 @@
                         <tbody>
                         {% for ah in assistantHistories %}
                             <tr>
-                                <td>
+                                <td class="table-menu">
                                     <div class="dropdown">
                                         <div class="clickable px-2" id="options-{{ ah.id }}" data-toggle="dropdown"
                                              aria-haspopup="true" aria-expanded="false">
@@ -146,9 +150,6 @@
                         </tbody>
 
                     </table>
-                    <button class="btn btn-outline-secondary csv_download_button" data-table-id="assistantTable"><i
-                                class="fa fa-download"></i> Last ned CSV
-                    </button>
                 </div>
             </div>
         </div>

--- a/app/Resources/views/receipt_admin/receipts_table_individual.html.twig
+++ b/app/Resources/views/receipt_admin/receipts_table_individual.html.twig
@@ -17,7 +17,7 @@
     <tbody>
     {% for receipt in receipts %}
         <tr>
-            <td>
+            <td class="table-menu">
                 {% if has_access_to('receipt_admin_edit') or has_access_to('receipt_admin_delete') %}
                     <div class="dropdown">
                         <div class="clickable px-2" id="options-{{ loop.index }}" data-toggle="dropdown"

--- a/app/Resources/views/receipt_admin/show_individual_receipts.html.twig
+++ b/app/Resources/views/receipt_admin/show_individual_receipts.html.twig
@@ -59,7 +59,7 @@
     {% if receipts is not empty %}
         <div class="card mt-3">
             <div class="card-header"><i class="fa fa-align-justify"></i> Utlegg ({{ receipts|length }})</div>
-            <div class="card-body table-responsive">
+            <div class="table-responsive">
                 {% include 'receipt_admin/receipts_table_individual.html.twig' with { 'receipts': receipts } %}
             </div>
         </div>

--- a/app/Resources/views/receipt_admin/show_receipts.html.twig
+++ b/app/Resources/views/receipt_admin/show_receipts.html.twig
@@ -69,7 +69,7 @@
 
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Utlegg</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive" style="padding-left:2px">
             <table class="table">
                 <thead>
                 <tr>

--- a/app/Resources/views/school_admin/all_users.html.twig
+++ b/app/Resources/views/school_admin/all_users.html.twig
@@ -61,7 +61,7 @@
 
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Brukere i {{ department }}</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
 
             <table id="table" class="table">
 

--- a/app/Resources/views/school_admin/assistant_history_table.html.twig
+++ b/app/Resources/views/school_admin/assistant_history_table.html.twig
@@ -1,4 +1,4 @@
-<div class="card-body table-responsive">
+<div class="table-responsive">
     <table class="table" width="100%" id="table">
         <thead>
         <tr>
@@ -16,7 +16,7 @@
         {% for ah in assistantHistories %}
             <tr>
                 {% if is_granted_team_leader() %}
-                    <td>
+                    <td class="table-menu">
                         <div class="dropdown">
                             <div class="clickable" id="options-{{ ah.id }}" data-toggle="dropdown"
                                  aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/school_admin/index.html.twig
+++ b/app/Resources/views/school_admin/index.html.twig
@@ -48,10 +48,10 @@
     <div class="row">
         <div class="col-12">
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade show active" id="active" role="tabpanel" aria-labelledby="active-tab">
+                <div class="tab-pane fade show active p-0" id="active" role="tabpanel" aria-labelledby="active-tab">
                     {% include 'school_admin/school_table.html.twig' with {schools: activeSchools }  %}
                 </div>
-                <div class="tab-pane fade" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
+                <div class="tab-pane fade p-0" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
                     {% include 'school_admin/school_table.html.twig' with {schools: inactiveSchools }  %}
                 </div>
             </div>

--- a/app/Resources/views/school_admin/school_table.html.twig
+++ b/app/Resources/views/school_admin/school_table.html.twig
@@ -1,5 +1,5 @@
 {% block school_table %}
-    <div class="card-body table-responsive">
+    <div class="table-responsive">
         <table class="table" width="100%" id="table">
             <thead>
             <tr>
@@ -18,7 +18,7 @@
             {% for s in schools %}
                 <tr>
                     {% if is_granted_team_leader() %}
-                        <td>
+                        <td class="table-menu">
                             <div class="dropdown">
                                 <div class="clickable" id="options-{{ s.id }}" data-toggle="dropdown"
                                      aria-haspopup="true" aria-expanded="false">

--- a/app/Resources/views/school_admin/specific_school.html.twig
+++ b/app/Resources/views/school_admin/specific_school.html.twig
@@ -45,10 +45,10 @@
     <div class="row">
         <div class="col-12">
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade show active" id="active" role="tabpanel" aria-labelledby="active-tab">
+                <div class="tab-pane fade show active p-0" id="active" role="tabpanel" aria-labelledby="active-tab">
                     {% include 'school_admin/assistant_history_table.html.twig' with {assistantHistories: activeAssistantHistories} %}
                 </div>
-                <div class="tab-pane fade" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
+                <div class="tab-pane fade p-0" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
                     {% include 'school_admin/assistant_history_table.html.twig' with {assistantHistories: inactiveAssistantHistories} %}
                 </div>
             </div>

--- a/app/Resources/views/semester_admin/index.html.twig
+++ b/app/Resources/views/semester_admin/index.html.twig
@@ -23,7 +23,7 @@
                 <div class="card-header">
                     <i class="fa fa-align-justify"></i> Semester
                 </div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
                     <table class="table">
 
                         <thead>

--- a/app/Resources/views/sponsors/sponsors_show.html.twig
+++ b/app/Resources/views/sponsors/sponsors_show.html.twig
@@ -18,7 +18,7 @@
 {% block body %}
     <div class="card">
         <div class="card-header"><i class="fa fa-align-justify"></i> Sponsorer ({{ sponsors|length }})</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
             <table class="table">
                 <tr>
                     <th></th>
@@ -30,7 +30,7 @@
 
                 {% for sponsor in sponsors %}
                     <tr>
-                        <td>
+                        <td class="table-menu">
                             {% if is_granted_team_leader() %}
                                 <div class="dropdown">
                                     <div class="clickable px-2" id="options-{{ loop.index }}" data-toggle="dropdown"

--- a/app/Resources/views/substitute/index.html.twig
+++ b/app/Resources/views/substitute/index.html.twig
@@ -54,8 +54,8 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-header"><i class="fa fa-align-justify"></i> Vikarer ({{ substitutes|length }})</div>
-                <div class="card-body table-responsive">
-                    <table width="100%" id="substitute-table" class="table">
+                <div class="table-responsive">
+                    <table width="100%" id="substitute-table" class="table table-striped">
                         <thead>
 
                         <tr>
@@ -122,7 +122,7 @@
                                 <td>{{ sub.thursday ? "Bra" : "Ikke" }}</td>
                                 <td>{{ sub.friday ? "Bra" : "Ikke" }}</td>
                                 <td>{{ sub.preferredGroup }}</td>
-                                {% if sub.interview is not null and sub.user != app.user and (is_granted_team_leader() or sub.interview.interviewer == app.user) %}
+                                {% if sub.interview is not null and sub.interview.interviewScore is not null and sub.user != app.user and (is_granted_team_leader() or sub.interview.interviewer == app.user) %}
                                     <td>{{ sub.interview.interviewScore.getSum() }}</td>
                                     <td>{{ sub.interview.interviewScore.suitableAssistant }}</td>
                                 {% else %}

--- a/app/Resources/views/survey/survey_table.html.twig
+++ b/app/Resources/views/survey/survey_table.html.twig
@@ -1,7 +1,7 @@
 <div class="card">
     <div class="card-header"><i class="fa fa-align-justify"></i>
         {{ cardTitle }}</div>
-    <div class="card-body">
+    <div class="table-responsive">
 
         <table class="table">
             <thead>
@@ -17,7 +17,7 @@
             {% for survey in surveys
                 if ((not survey.confidential) or has_access_to('survey_admin'))  %}
                 <tr>
-                    <td>
+                    <td class="table-menu">
                             {% if has_access_to('survey_admin') %}
                             <div class="dropdown">
                                 <div class="clickable px-2" id="options-{{ loop.index }}" data-toggle="dropdown"

--- a/app/Resources/views/team_admin/index.html.twig
+++ b/app/Resources/views/team_admin/index.html.twig
@@ -43,10 +43,10 @@
     <div class="row">
         <div class="col-12">
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade table-responsive show active" id="active" role="tabpanel" aria-labelledby="active-tab">
+                <div class="tab-pane fade table-responsive show active p-0" id="active" role="tabpanel" aria-labelledby="active-tab">
                     {% include 'team_admin/team_table.html.twig' with {'teams': active_teams} %}
                 </div>
-                <div class="tab-pane fade table-responsive" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
+                <div class="tab-pane fade table-responsive p-0" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
                     {% include 'team_admin/team_table.html.twig' with {'teams': inactive_teams} %}
                 </div>
             </div>

--- a/app/Resources/views/team_admin/show_applications.html.twig
+++ b/app/Resources/views/team_admin/show_applications.html.twig
@@ -21,7 +21,7 @@
                 <div class="card-header">
                     <i class="fa fa-align-justify"></i> Søknader til {{ team.name }} ({{ applications|length }})
                 </div>
-                <div class="card-body table-responsive">
+                <div class="table-responsive">
 
                     <table class="table">
                         <tr>

--- a/app/Resources/views/team_admin/specific_team.html.twig
+++ b/app/Resources/views/team_admin/specific_team.html.twig
@@ -46,10 +46,10 @@
     <div class="row">
         <div class="col-12">
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade show table-responsive active" id="active" role="tabpanel" aria-labelledby="active-tab">
+                <div class="tab-pane fade show table-responsive active p-0" id="active" role="tabpanel" aria-labelledby="active-tab">
                     {% include 'team_admin/team_membership_table.html.twig' with {'teamMemberships' : activeTeamMemberships} %}
                 </div>
-                <div class="tab-pane fade table-responsive" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
+                <div class="tab-pane fade table-responsive p-0" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
                     {% include 'team_admin/team_membership_table.html.twig' with {'teamMemberships' : inActiveTeamMemberships} %}
                 </div>
             </div>

--- a/app/Resources/views/team_admin/team_membership_table.html.twig
+++ b/app/Resources/views/team_admin/team_membership_table.html.twig
@@ -13,7 +13,7 @@
     {% for tm in teamMemberships %}
 
         <tr>
-            <td>
+            <td class="table-menu">
                 {% if is_granted_team_leader() %}
                     <div class="dropdown">
                         <div class="clickable px-2" id="options-{{ tm.id }}" data-toggle="dropdown"

--- a/app/Resources/views/team_admin/team_table.html.twig
+++ b/app/Resources/views/team_admin/team_table.html.twig
@@ -12,7 +12,7 @@
     <tbody>
     {% for team in teams %}
         <tr>
-            <td>
+            <td class="table-menu">
                 {% if is_granted_team_leader() %}
                     <div class="dropdown">
                         <div class="clickable px-2" id="options-{{ loop.index }}" data-toggle="dropdown"

--- a/app/Resources/views/todo_list/todo_list.twig
+++ b/app/Resources/views/todo_list/todo_list.twig
@@ -28,12 +28,12 @@
     <div class="card">
 
         <div class="card-header"><i class="fa fa-clipboard-list"></i> Gjøremål ({{ correctList|length }})</div>
-        <div class="card-body table-responsive">
+        <div class="table-responsive">
 
             <table width="100%" class="application-table table table-striped">
                 <thead>
                 <tr>
-                    <th/>
+                    <th></th>
                     <th>Tittel</th>
                     <th>Beskrivelse</th>
                     <th>Påbudt</th>
@@ -47,7 +47,7 @@
                 {% for item in correctList %}
 
                     <tr id="{{ item.id }}">
-                        <td>
+                        <td class="table-menu">
                             {% if has_access_to('edit_todo') %}
                                 <div class="dropdown">
                                     <div class="clickable px-2" id="options-{{ item.id }}" data-toggle="dropdown"

--- a/app/Resources/views/user_admin/index.html.twig
+++ b/app/Resources/views/user_admin/index.html.twig
@@ -71,10 +71,10 @@
     <div class="row">
         <div class="col-12">
             <div class="tab-content" id="myTabContent">
-                <div class="tab-pane fade show active" id="active" role="tabpanel" aria-labelledby="active-tab">
+                <div class="tab-pane fade show active p-0" id="active" role="tabpanel" aria-labelledby="active-tab">
                     {% include 'user_admin/user.table.html.twig' with {users: activeUsers} %}
                 </div>
-                <div class="tab-pane fade" id="inactive" role="tabpanel" aria-labelledby="inactive-tab">
+                <div class="tab-pane fade" id="inactive p-0" role="tabpanel" aria-labelledby="inactive-tab">
                     {% include 'user_admin/user.table.html.twig' with {users: inActiveUsers} %}
                 </div>
             </div>

--- a/app/Resources/views/user_admin/user.table.html.twig
+++ b/app/Resources/views/user_admin/user.table.html.twig
@@ -19,7 +19,7 @@
         <tbody>
         {% for u in users %}
             <tr>
-                <td>
+                <td class="table-menu">
                     {% if is_granted_admin() or (app.user.department == u.department and is_granted_team_leader()) %}
                         <div class="dropdown">
                             <div class="clickable px-2" id="options-{{ u.id }}" data-toggle="dropdown"

--- a/app/Resources/views/widgets/application_graph_widget.html.twig
+++ b/app/Resources/views/widgets/application_graph_widget.html.twig
@@ -3,7 +3,7 @@
         <div class="card-header">
             <i class="fa fa-users"></i> Søkere {{ semester }}
         </div>
-        <div class="card-body">
+        <div class="card-body p-0 p-lg-3">
             <div style="position: relative; width:100%">
                 <canvas id="applicationsChart"></canvas>
             </div>
@@ -19,7 +19,7 @@
     data: {
       labels: [{% for date, appCount in appData %}'{{ date|date('d.M') }}'{% if not loop.last %}, {% endif %}{% endfor %}],
       datasets: [{
-        label: 'Antall påmeldte',
+        label: 'Antall søkere',
         data: [{% for appCount in appData %}{{ appCount }}{% if not loop.last %}, {% endif %}{% endfor %}],
         backgroundColor: 'rgba(111, 206, 238, 0.2)',
         borderColor: 'rgba(111, 206, 238, 1)',
@@ -42,6 +42,9 @@
 
   function aspectRatio() {
     var width = document.body.clientWidth;
+    if (width < 550) {
+      return 1;
+    }
     if (width < 768) {
       return 2;
     }

--- a/app/Resources/views/widgets/interviews_widget.html.twig
+++ b/app/Resources/views/widgets/interviews_widget.html.twig
@@ -1,11 +1,12 @@
 {% if applications|length > 0 %}
     <div class="col-12 col-md-6 col-xxxl-4">
         <div class="card">
-            <div class="card-header">
-                <i class="fa fa-comments-o"></i> Dine Intervjuer
+            <div class="card-header d-flex justify-content-between">
+                <span><i class="fa fa-comments-o"></i> Dine Intervjuer</span>
+                <a class="text-muted" href="{{ path('applications_show_assigned') }}">Vis alle <i class="fa fa-chevron-right vertical-middle"></i></a>
             </div>
-            <div class="card-body table-responsive">
-                <table class="table table-striped mb-0">
+            <div class="table-responsive">
+                <table class="table mb-0">
                     <tr>
                         <th>Søker</th>
                         <th>Dato</th>

--- a/app/Resources/views/widgets/receipts_widget.html.twig
+++ b/app/Resources/views/widgets/receipts_widget.html.twig
@@ -1,11 +1,14 @@
 {% if has_access_to('receipts_show') %}
     <div class="col-12 col-md-6 col-xxxl-4">
         <div class="card">
-            <div class="card-header">
-                <i class="fa fa-usd"></i> Nye utlegg
+            <div class="card-header d-flex justify-content-between">
+                <span>
+                    <i class="fa fa-usd"></i> Nye utlegg
+                </span>
+                <a class="text-muted" href="{{ path('receipts_show') }}">Vis alle <i class="fa fa-chevron-right vertical-middle"></i></a>
             </div>
-            <div class="card-body table-responsive">
-                <table class="table table-striped mb-0">
+            <div class="table-responsive">
+                <table class="table mb-0">
                     <tr>
                         <th>Navn</th>
                         <th class="text-right">Beløp</th>

--- a/src/AppBundle/Controller/AdmissionPeriodController.php
+++ b/src/AppBundle/Controller/AdmissionPeriodController.php
@@ -95,7 +95,7 @@ class AdmissionPeriodController extends BaseController
         $em = $this->getDoctrine()->getManager();
         $infoMeeting = $admissionPeriod->getInfoMeeting();
         if ($infoMeeting) {
-        	$em->remove($infoMeeting);
+            $em->remove($infoMeeting);
         }
         $em->remove($admissionPeriod);
         $em->flush();

--- a/src/AppBundle/Controller/AdmissionPeriodController.php
+++ b/src/AppBundle/Controller/AdmissionPeriodController.php
@@ -93,9 +93,13 @@ class AdmissionPeriodController extends BaseController
     public function deleteAction(AdmissionPeriod $admissionPeriod)
     {
         $em = $this->getDoctrine()->getManager();
+        $infoMeeting = $admissionPeriod->getInfoMeeting();
+        if ($infoMeeting) {
+        	$em->remove($infoMeeting);
+        }
         $em->remove($admissionPeriod);
         $em->flush();
 
-        return new JsonResponse(array('success' => true));
+        return $this->redirectToRoute('admission_period_admin_show_by_department', ['id' => $admissionPeriod->getDepartment()->getId()]);
     }
 }

--- a/src/AppBundle/Controller/WidgetController.php
+++ b/src/AppBundle/Controller/WidgetController.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Receipt;
 use AppBundle\Service\AdmissionStatistics;
+use AppBundle\Service\Sorter;
 use AppBundle\Utils\ReceiptStatistics;
 
 class WidgetController extends BaseController
@@ -27,7 +28,12 @@ class WidgetController extends BaseController
     public function receiptsAction()
     {
         $usersWithReceipts = $this->getDoctrine()->getRepository('AppBundle:User')->findAllUsersWithReceipts();
-        $pendingReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_PENDING);
+	    $sorter = $this->container->get(Sorter::class);
+
+	    $sorter->sortUsersByReceiptSubmitTime($usersWithReceipts);
+	    $sorter->sortUsersByReceiptStatus($usersWithReceipts);
+
+	    $pendingReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_PENDING);
 
         $pendingReceiptStatistics = new ReceiptStatistics($pendingReceipts);
 

--- a/src/AppBundle/Controller/WidgetController.php
+++ b/src/AppBundle/Controller/WidgetController.php
@@ -28,12 +28,12 @@ class WidgetController extends BaseController
     public function receiptsAction()
     {
         $usersWithReceipts = $this->getDoctrine()->getRepository('AppBundle:User')->findAllUsersWithReceipts();
-	    $sorter = $this->container->get(Sorter::class);
+        $sorter = $this->container->get(Sorter::class);
 
-	    $sorter->sortUsersByReceiptSubmitTime($usersWithReceipts);
-	    $sorter->sortUsersByReceiptStatus($usersWithReceipts);
+        $sorter->sortUsersByReceiptSubmitTime($usersWithReceipts);
+        $sorter->sortUsersByReceiptStatus($usersWithReceipts);
 
-	    $pendingReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_PENDING);
+        $pendingReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_PENDING);
 
         $pendingReceiptStatistics = new ReceiptStatistics($pendingReceipts);
 


### PR DESCRIPTION
Tables har allerede nok padding rundt innholdet sitt, så det blir i overkant mye padding når man lagger til padding fra `.card-body`. Har derfor fjernet `.card-body` fra cards som kun inneholder en table. 

Har også redusert padding på `.container-fluid` fra 30px til 15px (som er default i bootstrap) for å gi mer plass i kontrollpanelet på mobil