### PR TITLE
Spesifiser hvilke brukernavn/passord nye teammedlemmer skal logge inn med

### DIFF
--- a/app/Resources/views/team_admin/welcome_team_membership_mail.html.twig
+++ b/app/Resources/views/team_admin/welcome_team_membership_mail.html.twig
@@ -47,7 +47,7 @@
                     <img src="https://vektorprogrammet.no{{ asset('images/email_images/vektormail_signin.PNG')}}" alt="Vektormail" class="float-center" style="max-width: 400px; margin: 2px">
                 </li>
                 <li>
-                    Logg inn på samme måte som på vektorprogrammet.no
+                    Logg inn på samme måte som på vektorprogrammet.no (samme brukernavn og passord)
                     <img src="https://vektorprogrammet.no{{ asset('images/email_images/vektor_signin.PNG') }}" alt="Sign in" class="float-center" style="max-width: 400px; margin: 2px">
                 </li>
                 <li>Du er nå logget inn i <b>gsuite</b>!</li>


### PR DESCRIPTION
Det er ingen som skjønner at de skal bruke samme login-info i gsuite og på vektorprogrammet.no, så her er et forsøk på å tydeliggjøre dette i velkomstmailen. 