### PR TITLE
Add department to group names on google admin

### DIFF
--- a/src/AppBundle/Google/GoogleGroups.php
+++ b/src/AppBundle/Google/GoogleGroups.php
@@ -173,7 +173,8 @@ class GoogleGroups extends GoogleService
         return false;
     }
 
-    private function setGroupNameEmailDescription(\Google_Service_Directory_Group $googleGroup, Team $team){
+    private function setGroupNameEmailDescription(\Google_Service_Directory_Group $googleGroup, Team $team)
+    {
         $googleGroup->setName($team->getName() - $team->getDepartment());
         $googleGroup->setEmail($team->getEmail());
         $googleGroup->setDescription($team->getShortDescription());

--- a/src/AppBundle/Google/GoogleGroups.php
+++ b/src/AppBundle/Google/GoogleGroups.php
@@ -73,9 +73,7 @@ class GoogleGroups extends GoogleService
         $service = new Google_Service_Directory($client);
 
         $googleGroup = new \Google_Service_Directory_Group();
-        $googleGroup->setName($team->getName());
-        $googleGroup->setEmail($team->getEmail());
-        $googleGroup->setDescription($team->getShortDescription());
+        $this->setGroupNameEmailDescription($googleGroup, $team);
 
         try {
             $createdGroup = $service->groups->insert($googleGroup);
@@ -102,9 +100,7 @@ class GoogleGroups extends GoogleService
         $service = new Google_Service_Directory($client);
 
         $googleGroup = new \Google_Service_Directory_Group();
-        $googleGroup->setName($team->getName());
-        $googleGroup->setEmail($team->getEmail());
-        $googleGroup->setDescription($team->getShortDescription());
+        $this->setGroupNameEmailDescription($googleGroup, $team);
 
         try {
             $updatedTeam =  $service->groups->update($groupEmail, $googleGroup);
@@ -175,5 +171,11 @@ class GoogleGroups extends GoogleService
         }
 
         return false;
+    }
+
+    private function setGroupNameEmailDescription(\Google_Service_Directory_Group $googleGroup, Team $team){
+        $googleGroup->setName($team->getName() - $team->getDepartment());
+        $googleGroup->setEmail($team->getEmail());
+        $googleGroup->setDescription($team->getShortDescription());
     }
 }

--- a/src/AppBundle/Google/GoogleGroups.php
+++ b/src/AppBundle/Google/GoogleGroups.php
@@ -175,7 +175,7 @@ class GoogleGroups extends GoogleService
 
     private function setGroupNameEmailDescription(\Google_Service_Directory_Group $googleGroup, Team $team)
     {
-        $googleGroup->setName($team->getName() - $team->getDepartment());
+        $googleGroup->setName($team->getName() . " - " . $team->getDepartment());
         $googleGroup->setEmail($team->getEmail());
         $googleGroup->setDescription($team->getShortDescription());
     }


### PR DESCRIPTION
The current group names are somewhat confusing on the google admin page. This states clearly which department the group comes from. 
<img width="782" alt="Screenshot 2019-08-26 at 15 54 00" src="https://user-images.githubusercontent.com/31702423/63706519-ea36f880-c82f-11e9-90b5-c894d52db8c2.png">
