### PR TITLE
Add a link to admission page and move description up in infomeeting mail

### DIFF
--- a/app/Resources/views/admission/info_meeting_email.html.twig
+++ b/app/Resources/views/admission/info_meeting_email.html.twig
@@ -5,16 +5,18 @@
 {% if infoMeeting.room %}
 i rom {{ infoMeeting.room }}
 {% endif %}!</p>
-{% if infoMeeting.link %}
-    <p>Link til arrangement: <a href="{{ infoMeeting.link }}">{{ infoMeeting.link }}</a></p>
-{% endif %}
-
 
 {% if infoMeeting.description %}
     <p>{{ infoMeeting.description }}</p>
 {% endif %}
 
-<br>
+{% if infoMeeting.link %}
+    <p>Link til arrangement: <a href="{{ infoMeeting.link }}">{{ infoMeeting.link }}</a></p>
+{% endif %}
+
+<p>Dersom du ønsker å søke allerede nå kan du gjøre det her: <a
+                href="https://vektorprogrammet.no{{ path('admission_show_by_city_case_insensitive', {'city': department}) }}">https://vektorprogrammet.no{{ path('admission_show_by_city_case_insensitive', {'city': department}) }}</a>.
+</p>
 <a href="https://vektorprogrammet.no{{ path('home') }}">
     <img src="https://vektorprogrammet.no/images/vektor.png" alt="https://vektorprogrammet.no{{ path('home') }}">
 </a>


### PR DESCRIPTION
Det kom inn noen forespørsler om å fikse på infomøte varselet nå i siste liten. De ville ha inn en link til opptaket. Flyttet også beskrivelsen ovenfor link til fb da dette så mer naturlig ut.

![image](https://user-images.githubusercontent.com/5937246/63797747-f80c7c80-c908-11e9-81c3-e1ca0f2b54b4.png)


`department` sendes allerede inn som parameter i det templaten renderes, så derfor er ingenting endret der.