### PR TITLE
Legg til csv-nedlastning av undersøkelsesresultater

### DIFF
--- a/app/Resources/views/survey/survey_result.html.twig
+++ b/app/Resources/views/survey/survey_result.html.twig
@@ -16,8 +16,8 @@
     <header class="row">
         <div class="col-12">
             <h3>Resultater for {{ survey.name }} {{ survey.semester }} </h3>
-            <a id="download-json-btn" class="text-primary" download="survey{{survey.id}}.json"
-               href="{{ path('survey_get_all_results', {'id': survey.id } ) }}">Last ned json</a>
+            <a id="download-csv-btn" class="text-primary" download="survey{{survey.id}}.csv"
+               href="{{ path('survey_get_results_csv', {'id': survey.id } ) }}">Last ned csv</a>
         </div>
     </header>
     <a id="show-filter-btn" class="text-primary">Vis/skjul filter&nbsp;&nbsp;<i

--- a/app/Resources/views/survey/survey_result.html.twig
+++ b/app/Resources/views/survey/survey_result.html.twig
@@ -16,10 +16,12 @@
     <header class="row">
         <div class="col-12">
             <h3>Resultater for {{ survey.name }} {{ survey.semester }} </h3>
-            <a id="show-filter-btn" class="text-primary">Vis/skjul filter&nbsp;&nbsp;<i
-                        class="fa fa-chevron-right"></i></a>
+            <a id="download-json-btn" class="text-primary" download="survey{{survey.id}}.json"
+               href="{{ path('survey_get_all_results', {'id': survey.id } ) }}">Last ned json</a>
         </div>
     </header>
+    <a id="show-filter-btn" class="text-primary">Vis/skjul filter&nbsp;&nbsp;<i
+                class="fa fa-chevron-right"></i></a>
     <div id="filter"></div>
     <div class="row equalheight charts" id="charts">
         <h1 class="text-center">Laster data... <i class="fa fa-spinner"></i></h1>

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -180,6 +180,13 @@ survey_results:
  requirements:
   id: \d+
 
+survey_get_results_csv:
+ path: /kontrollpanel/undersokelse/resultater/{id}.csv
+ defaults: { _controller: AppBundle:Survey:getSurveyResultCSV }
+ methods: [GET]
+ requirements:
+  id: \d+
+
 survey_get_all_results:
  path: /kontrollpanel/api/undersokelse/resultat/{id}
  defaults: { _controller: AppBundle:Survey:getSurveyResult }

--- a/src/AppBundle/Controller/SurveyController.php
+++ b/src/AppBundle/Controller/SurveyController.php
@@ -13,14 +13,11 @@ use AppBundle\Form\Type\SurveyExecuteType;
 use AppBundle\Form\Type\SurveyType;
 use AppBundle\Service\AccessControlService;
 use AppBundle\Service\SurveyManager;
-use Doctrine\ORM\EntityManager;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use function Clue\StreamFilter\append;
 
 /**
  * SurveyController is the controller responsible for survey actions,

--- a/src/AppBundle/Controller/SurveyController.php
+++ b/src/AppBundle/Controller/SurveyController.php
@@ -442,7 +442,7 @@ class SurveyController extends BaseController
 
         $sm = $this->get(SurveyManager::class);
 
-        //All completed surveys, each element being a map from question_id=>answer
+        //A 2d array of all completed surveys, each element being a map from question_id=>answer
         $csv_rows = array();
         foreach($surveysTaken as $taken) {
             $csv_row = array();
@@ -467,6 +467,7 @@ class SurveyController extends BaseController
             $csv_rows[]=$csv_row;
         }
 
+        //Export the two-dimensional csv array to a csv string
         $content = "";
         foreach($questions as $question) {
             $content .= $this->csv_escape_and_separate($question);

--- a/src/AppBundle/Controller/SurveyController.php
+++ b/src/AppBundle/Controller/SurveyController.php
@@ -470,17 +470,17 @@ class SurveyController extends BaseController
         //Export the two-dimensional csv array to a csv string
         $content = "";
         foreach($questions as $question) {
-            $content .= $this->csv_escape_and_separate($question);
+            $content .= $this->csvEscapeAndSeparate($question);
         }
-        $content = $this->csv_newline($content);
+        $content = $this->csvNewline($content);
         foreach($csv_rows as $csv_row) {
             foreach($questions as $id=>$qname) {
                 if(isset($csv_row[$id]))
-                    $content .= $this->csv_escape_and_separate($csv_row[$id]);
+                    $content .= $this->csvEscapeAndSeparate($csv_row[$id]);
                 else
-                    $content .= $this->csv_escape_and_separate("");
+                    $content .= $this->csvEscapeAndSeparate("");
             }
-            $content = $this->csv_newline($content);
+            $content = $this->csvNewline($content);
         }
 
         $response = new Response($content);
@@ -489,13 +489,13 @@ class SurveyController extends BaseController
     }
 
     //Escapes the string, quotes it and adds a separator (default: comma)
-    private function csv_escape_and_separate(string $str, string $sep=','):string {
+    private function csvEscapeAndSeparate(string $str, string $sep=','):string {
         $str=str_replace('"', '""', $str); //" is escaped with "" in csv
         return "\"$str\"$sep";
     }
 
     //Removes the last separator and replaces it with a csv newline
-    private function csv_newline(string $csv):string {
+    private function csvNewline(string $csv):string {
         return substr($csv, 0, -1)."\r\n";
     }
 

--- a/src/AppBundle/Service/SurveyManager.php
+++ b/src/AppBundle/Service/SurveyManager.php
@@ -135,7 +135,6 @@ class SurveyManager
         return $textQAarray;
     }
 
-
     public function getTextAnswerWithTeamResults(Survey $survey): array
     {
         $textQuestionArray = array();

--- a/src/AppBundle/Service/SurveyManager.php
+++ b/src/AppBundle/Service/SurveyManager.php
@@ -176,6 +176,12 @@ class SurveyManager
         return $textQAarray;
     }
 
+    public function getTeamNamesForSurveyTaker(SurveyTaken $taken):string {
+        $user = $taken->getUser();
+        $ua = $this->getUserAffiliationOfUserBySemester($user, $taken->getSurvey()->getSemester());
+        $teamNames = $this->getTeamNamesAsString($ua);
+        return $teamNames;
+    }
 
     private function getTeamNamesAsString(array $teamNames): string
     {


### PR DESCRIPTION
PR legger til en lenke til csv-nedlastning på resultatsiden til spørreundersøkelser.
CSV-responsen lages på server, og inkluderer en header med spørsmålene.
På undersøkelser der det spørres om skole, vil skole være en kolonne i tabellen.
På andre undersøkelser (team-undersøkelser) vil team-tilhørighet være en kolonne.

Jeg har ikke skrevet noen tester, men har i det minste prøvd å svare `"`, `\`, newline og japanske tegn, og de funker helt fint i csv-filen.

Laster opp som draft så dere kan se, og si hvordan man eventuelt skulle skrevet tester.