### PR TITLE
correct github link on changelog items

### DIFF
--- a/app/Resources/views/widgets/changelog_widget.html.twig
+++ b/app/Resources/views/widgets/changelog_widget.html.twig
@@ -18,11 +18,9 @@
                             {{ changeLogItem.description | safe_html }}
                         </p>
                         <div class="d-flex justify-content-lg-start">
-                            <span>Les mer på github:
-                                <a href="{{ changeLogItem.githubLink }}">
-                                    {{ changeLogItem.githubLink | trim('https://') | split("/")[0] }}
-                                </a>
-                            </span>
+                            <a href="{{ changeLogItem.githubLink }}">
+                                Les mer på GitHub
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/app/Resources/views/widgets/changelog_widget.html.twig
+++ b/app/Resources/views/widgets/changelog_widget.html.twig
@@ -17,10 +17,12 @@
                         <p>
                             {{ changeLogItem.description | safe_html }}
                         </p>
-                        <div class="d-flex justify-content-between">
-                            <a href="{{ changeLogItem.githubLink }}">
-                                {{ changeLogItem.githubLink | trim('https://') | split("m")[0] }}
-                            </a>
+                        <div class="d-flex justify-content-lg-start">
+                            <span>Les mer på github:
+                                <a href="{{ changeLogItem.githubLink }}">
+                                    {{ changeLogItem.githubLink | trim('https://') | split("/")[0] }}
+                                </a>
+                            </span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Also add declarative text

Closes #1259 

<img width="453" alt="Screenshot 2019-10-09 at 20 22 32" src="https://user-images.githubusercontent.com/31702423/66509049-8d875880-ead2-11e9-8407-a1176c0aaa5b.png">
