### PR TITLE
change method used to check for active membership on sso login

### DIFF
--- a/src/AppBundle/Controller/SsoController.php
+++ b/src/AppBundle/Controller/SsoController.php
@@ -36,7 +36,7 @@ class SsoController extends BaseController
             return $response;
         }
 
-        $activeInTeam = count($user->getActiveTeamMemberships()) > 0;
+        $activeInTeam = count($user->getActiveMemberships()) > 0;
         if (!$activeInTeam) {
             $response->setStatusCode(401);
             $response->setContent('User does not have any active team memberships');


### PR DESCRIPTION
Previously, the login checked only team memberships. This caused issues for the members of the executive board, because these memberships are not like those for teams, but rather their own entities.