### PR TITLE
Remove autocomplete from admission subscriber form

### DIFF
--- a/app/Resources/views/admission_subscriber/subscribe_page.html.twig
+++ b/app/Resources/views/admission_subscriber/subscribe_page.html.twig
@@ -17,10 +17,7 @@
         </div>
         <div class="row">
             <div class="col-12 col-sm-8 offset-sm-2 col-md-6 offset-md-3 col-lg-4 offset-lg-4 text-center">
-                {{ form_start(form, { 'attr': {'autocomplete': 'nope'} }) }}
-                {{ form_row(form.email) }}
-                {{ form_row(form.infoMeeting) }}
-                <button class="btn btn-success">Meld deg på interesseliste</button>
+                {{ form_start(form) }}
                 {{ form_end(form) }}
             </div>
         </div>

--- a/src/AppBundle/Form/Type/AdmissionSubscriberType.php
+++ b/src/AppBundle/Form/Type/AdmissionSubscriberType.php
@@ -5,7 +5,9 @@ namespace AppBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AdmissionSubscriberType extends AbstractType
@@ -16,7 +18,8 @@ class AdmissionSubscriberType extends AbstractType
             ->add('email', EmailType::class, array(
             'label' => false,
             'attr' => [
-                'placeholder' => 'E-post'
+                'placeholder' => 'E-post',
+                'autocomplete' => 'off'
             ]
             ))
             ->add('infoMeeting', CheckboxType::class, array(
@@ -24,6 +27,12 @@ class AdmissionSubscriberType extends AbstractType
             'required' => false,
             'attr' => [
                 'checked' => true
+            ]
+            ))
+            ->add('submit', SubmitType::class, array(
+            'label' => 'Meld deg på interesseliste',
+            'attr' => [
+                'class' => 'btn btn-success'
             ]
             ));
     }

--- a/src/AppBundle/Form/Type/AdmissionSubscriberType.php
+++ b/src/AppBundle/Form/Type/AdmissionSubscriberType.php
@@ -7,7 +7,6 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AdmissionSubscriberType extends AbstractType


### PR DESCRIPTION
Also removes form items from twig, and puts the submit button into `AdmissionSubscriberType.php`
Fixes #1291 
