### PR TITLE
Change language choice from radio buttons to dropdown

### DIFF
--- a/src/AppBundle/Form/Type/ApplicationPracticalType.php
+++ b/src/AppBundle/Form/Type/ApplicationPracticalType.php
@@ -57,8 +57,6 @@ class ApplicationPracticalType extends AbstractType
                 'Engelsk' => 'Engelsk',
                 'Norsk og engelsk' => 'Norsk og engelsk',
             ),
-            'data' => 'Norsk',
-            'expanded' => true,
             'multiple' => false,
         ));
 

--- a/src/AppBundle/Form/Type/ApplicationPracticalType.php
+++ b/src/AppBundle/Form/Type/ApplicationPracticalType.php
@@ -57,6 +57,8 @@ class ApplicationPracticalType extends AbstractType
                 'Engelsk' => 'Engelsk',
                 'Norsk og engelsk' => 'Norsk og engelsk',
             ),
+            'empty_data' => 'Norsk',
+            'expanded' => true,
             'multiple' => false,
         ));
 


### PR DESCRIPTION
Also removed the data parameter to stop it from overwriting data from
old interview. By doing this, the desired effect ('Norsk' by default) is
achieved while still not overwriting if the previous answer was 'Engelsk'
or 'Norsk og engelsk'

Closes #1297