### PR TITLE
[WIP] Add a containerized development environment with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env.*.php
 .env.php
 .env
-
+.v8flags*
 
 ### PhpStorm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,20 @@ EXPOSE 8000
 
 # Tell packages to not ask for user input
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y php7.2 php7.2-mbstring php7.2-sqlite php7.2-gd php7.2-curl php7.2-xml nodejs npm git zip unzip
-
-RUN echo "PHP extensions: "
-RUN php -m
-RUN echo "PHP .ini files: "
-RUN php -i
-
-# Make some changes to php.ini file. Many extensions are already enabled in other files
-#RUN sed -i 's/;extension=mbstring/extension=mbstring/' /etc/php/7.2/cli/php.ini
-#RUN sed -i 's/;extension=pdo_sqlite/extension=pdo_sqlite/' /etc/php/7.2/cli/php.ini
-#RUN sed -i 's/;extension=gd2/extension=gd2/' /etc/php/7.2/cli/php.ini
-#RUN sed -i 's/;extension=curl/extension=curl/' /etc/php/7.2/cli/php.ini
-#RUN sed -i 's/;extension=xml/extension=xml/' /etc/php/7.2/cli/php.ini
-RUN sed -i 's/display_errors = Off/display_errors = On/' /etc/php/7.2/cli/php.ini
-RUN sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini
+RUN apt-get update \
+    && apt-get install -y php7.2 php7.2-mbstring php7.2-sqlite php7.2-gd php7.2-curl php7.2-xml nodejs npm git zip unzip \
+    && echo "PHP extensions: " \
+    && php -m \
+    && echo "PHP .ini files: " \
+    && php -i \
+    # Make some changes to php.ini file. Many extensions are already enabled in other files
+    #sed -i 's/;extension=mbstring/extension=mbstring/' /etc/php/7.2/cli/php.ini
+    #sed -i 's/;extension=pdo_sqlite/extension=pdo_sqlite/' /etc/php/7.2/cli/php.ini
+    #sed -i 's/;extension=gd2/extension=gd2/' /etc/php/7.2/cli/php.ini
+    #sed -i 's/;extension=curl/extension=curl/' /etc/php/7.2/cli/php.ini
+    #sed -i 's/;extension=xml/extension=xml/' /etc/php/7.2/cli/php.ini
+    && sed -i 's/display_errors = Off/display_errors = On/' /etc/php/7.2/cli/php.ini \
+    && sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini
 
 # This is what we /would/ do if we didn't mount the entire folder into the container
 # COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN php -i
 RUN sed -i 's/display_errors = Off/display_errors = On/' /etc/php/7.2/cli/php.ini
 RUN sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini
 
-# Kopierer inn alt for å kjøre
-COPY . .
-RUN npm run setup
+# Vi kopierer ikke inn noe. Vi lar heller hele mappen mountes
+# COPY . .
+# RUN npm run setup
 
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,22 @@
-# Dockerfile for å kjøre vektorprogrammets binaries i ubuntu 18.04, men likevel hente all php-kildekode fra host-systemet
-# Bruk:
-#
+# Dockerfile for making ubuntu:18.04 into a php/node environment for running and developing vektorprogrammet
+# Usage: See docker.md
 
 FROM ubuntu:18.04
 RUN mkdir /app
 WORKDIR /app
 EXPOSE 8000
 
-# Sånn at kommandoer ikke ber om bruker-input
+# Tell packages to not ask for user input
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y php7.2 php7.2-mbstring php7.2-sqlite php7.2-gd php7.2-curl php7.2-xml nodejs npm git zip unzip
 
-RUN echo "PHP-moduler (extensions): "
+RUN echo "PHP extensions: "
 RUN php -m
-RUN echo "PHP-inier: "
+RUN echo "PHP .ini files: "
 RUN php -i
 
-# Endre php.ini-fil
+# Make some changes to php.ini file. Many extensions are already enabled in other files
 #RUN sed -i 's/;extension=mbstring/extension=mbstring/' /etc/php/7.2/cli/php.ini
 #RUN sed -i 's/;extension=pdo_sqlite/extension=pdo_sqlite/' /etc/php/7.2/cli/php.ini
 #RUN sed -i 's/;extension=gd2/extension=gd2/' /etc/php/7.2/cli/php.ini
@@ -26,8 +25,9 @@ RUN php -i
 RUN sed -i 's/display_errors = Off/display_errors = On/' /etc/php/7.2/cli/php.ini
 RUN sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini
 
-# Vi kopierer ikke inn noe. Vi lar heller hele mappen mountes
+# This is what we /would/ do if we didn't mount the entire folder into the container
 # COPY . .
 # RUN npm run setup
 
+# Default command for running, will complain about no package.json if app/ isn't mounted
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Dockerfile for å kjøre vektorprogrammets binaries i ubuntu 18.04, men likevel hente all php-kildekode fra host-systemet
+# Bruk:
+#
+
+FROM ubuntu:18.04
+RUN mkdir /app
+WORKDIR /app
+EXPOSE 8000
+
+# Sånn at kommandoer ikke ber om bruker-input
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y php7.2 php7.2-mbstring php7.2-sqlite php7.2-gd php7.2-curl php7.2-xml nodejs npm git zip unzip
+
+RUN echo "PHP-moduler (extensions): "
+RUN php -m
+RUN echo "PHP-inier: "
+RUN php -i
+
+# Endre php.ini-fil
+#RUN sed -i 's/;extension=mbstring/extension=mbstring/' /etc/php/7.2/cli/php.ini
+#RUN sed -i 's/;extension=pdo_sqlite/extension=pdo_sqlite/' /etc/php/7.2/cli/php.ini
+#RUN sed -i 's/;extension=gd2/extension=gd2/' /etc/php/7.2/cli/php.ini
+#RUN sed -i 's/;extension=curl/extension=curl/' /etc/php/7.2/cli/php.ini
+#RUN sed -i 's/;extension=xml/extension=xml/' /etc/php/7.2/cli/php.ini
+RUN sed -i 's/display_errors = Off/display_errors = On/' /etc/php/7.2/cli/php.ini
+RUN sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini
+
+# Kopierer inn alt for å kjøre
+COPY . .
+RUN npm run setup
+
+CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN mkdir /app
 WORKDIR /app
 EXPOSE 8000
 
-# Tell packages to not ask for user input
-ENV DEBIAN_FRONTEND=noninteractive
+# Set correct environment
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
+
 RUN apt-get update \
     && apt-get install -y php7.2 php7.2-mbstring php7.2-sqlite php7.2-gd php7.2-curl php7.2-xml nodejs npm git zip unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && echo "PHP extensions: " \
     && php -m \
     && echo "PHP .ini files: " \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 # Usage: See docker.md
 
 FROM ubuntu:18.04
-RUN mkdir /app
+RUN mkdir -p /app /tmp
 WORKDIR /app
 EXPOSE 8000
 
 # Set correct environment
-ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 TMPDIR=/tmp
 
 RUN apt-get update \
     && apt-get install -y php7.2 php7.2-mbstring php7.2-sqlite php7.2-gd php7.2-curl php7.2-xml nodejs npm git zip unzip \
@@ -23,7 +23,9 @@ RUN apt-get update \
     #sed -i 's/;extension=curl/extension=curl/' /etc/php/7.2/cli/php.ini
     #sed -i 's/;extension=xml/extension=xml/' /etc/php/7.2/cli/php.ini
     && sed -i 's/display_errors = Off/display_errors = On/' /etc/php/7.2/cli/php.ini \
-    && sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini
+    && sed -i 's/display_startup_errors = Off/display_startup_errors = On/' /etc/php/7.2/cli/php.ini \
+    && sed -i 's~; sys_temp_dir.*$~sys_temp_dir = "/tmp"~' /etc/php/7.2/cli/php.ini
+
 
 # This is what we /would/ do if we didn't mount the entire folder into the container
 # COPY . .

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 
 # Set up development environment
+There is also an option to use a docker image as your environment, see [docker.md].
 ## Requirements:
 - [PHP](http://php.net/downloads.php) version >= 7.1
 - [Node](https://nodejs.org/en/) version >= 8
@@ -18,17 +19,7 @@
 * ext-xml
 
 #### How to install the php-dependencies
-
-Please find the file `php.ini`. (On Linux it is located at `/etc/php/version/cli/php.ini`).
-
-Uncomment all lines with the required PHP-dependencies.
-
-Example for dependency `mbstring`:
-
-`;extension=mbstring`       ---> `extension=mbstring`
-
-
-To install the PHP-dependencies on Ubuntu 
+To install the php-dependencies on Ubuntu 
 (Example with Ubuntu as operating system and a php-version of 7.2)
 ```
 sudo apt-get install php7.2-mbstring
@@ -38,8 +29,14 @@ sudo apt-get install php7.2-curl
 sudo apt-get install php7.2-xml
 ```
 
+To see which modules are enabled, run `php -m`. If one of the required modules
+is missing, add it to `php.ini`. Run `php -i` to see where the ini file is located.
 
-
+Uncomment all lines with the missing PHP-dependencies. Example for dependency
+`mbstring`:
+```
+;extension=mbstring       ---> extension=mbstring
+```
 
 ## Setup:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 # Set up development environment
-There is also an option to use a docker image as your environment, see [docker.md].
+There is also an option to use a docker image as your environment, see [docker.md](docker.md).
 ## Requirements:
 - [PHP](http://php.net/downloads.php) version >= 7.1
 - [Node](https://nodejs.org/en/) version >= 8

--- a/docker.md
+++ b/docker.md
@@ -1,7 +1,7 @@
 # Using docker
 By using docker we can run the server inside a *container*, which has its own
-file system and binaries. This allows us to get a working environment with the
-correct versions of `php`, `npm` etc. on any host machine. First we prepare a
+file system and binaries. This allows us to get a working environment with
+working versions of `php`, `npm` etc. on any host machine. First we prepare a
 docker *image*, which is a snapshot of a filesystem with everything set up. Then
 we can start a container from the image, and run commands inside it.
 
@@ -13,20 +13,19 @@ npm run docker:dev:build
 ```
 This will start a new container based on `unbuntu:18.04`, install `php7.2`,
 `npm` etc., and make an empty `/app` folder. When we later start our container,
-we will mount the development directory into the `/app` folder. We don't want to
-rebuild the docker image while developing, so we simply use docker for the
-binaries, and mount in the actual folder. This means we don't even have to
-restart the container for changes to take effect.
+we will mount the `vektorprogrammet/` development directory into the `/app`
+folder. We don't want to rebuild the docker image while developing, so we simply
+use docker for the binaries, and mount in the actual folder. This means we don't
+even have to restart the container for changes to take effect.
 
 ## Running setup
-We need to get all npm and php requirements, so run
+We need to get all npm and php requirements installed, so run
 ```
 npm run docker:dev:setup
 ```
 This will run `npm run setup` inside a docker container based on the
 `vektordev:1.0` image, but the setup will happen in the `vektorprogrammet/`
-folder on the host machine. `vektorprogrammet/` is mounted into `app/` in the
-container.
+folder on the host machine.
 
 ## Running the server
 To start the server, simply run
@@ -34,7 +33,20 @@ To start the server, simply run
 npm run docker:dev:start
 ```
 This will run `npm start` in a new container, but the server will still run from
-the the `vektorprogrammet/` folder on the host machine. This means the server
-will behave as if there were no container. The port `8000` is passed through the
-container to the host machine, so open [0.0.0.0:8000] to access the server
+the `vektorprogrammet/` folder on the host machine. This means the server will
+behave as if there were no container. The port `8000` is passed through the
+container to the host machine, so open [0.0.0.0:8000] to access the server 
 normally.
+
+## Running other commands
+Sometimes you may want to run other commands, like
+* `npm run dp:update` to update the database and reload fixtures
+* `npm run cs` to fix code style problems
+* `npm run test` to do tests
+
+These must also be run from within the container with the `vektorprogrammet/`
+folder mounted. This is the general command used by all in-container operations:
+```
+npm run docker:dev:run -- <your> <command> <here>
+```
+

--- a/docker.md
+++ b/docker.md
@@ -1,35 +1,40 @@
-# Bruk av Docker
-Ved å bruke docker slipper du å installere programmer og sette opp systemet ditt
-med riktige versjoner og konfigurasjoner av php og slik. Docker lar deg bygge et
-*image*, som er et viritruelt filsystem der akkurat de riktige programmene er
-installert. Dette bildet kan så startes som en *container*, og vektorprogrammets
-server kan kjøres inni den containeren.
+# Using docker
+By using docker we can run the server inside a *container*, which has its own
+file system and binaries. This allows us to get a working environment with the
+correct versions of `php`, `npm` etc. on any host machine. First we prepare a
+docker *image*, which is a snapshot of a filesystem with everything set up. Then
+we can start a container from the image, and run commands inside it.
 
-## Lag docker-bildet
-I repoet ligger `/Dockerfile`, som beskriver hvilke kommandoer som skal
-kjøres for å omdanne en fersk installasjon av `ubuntu 18.04` til en velsmurt
-vektorprogrammet-utviklings-server.
+## Making the docker image
+The file `/Dockerfile` describes how to turn a clean install of ubuntu 18.04
+into a well-oiled development server. To build the image, run
 ```
 npm run docker:dev:build
 ```
-Dette vil starte en ny container, installere `php7.2`, `npm` osv, og kopiere
-all vektorprogrammet-koden inn i det viritruelle filsystemet. Deretter kjøres
-`npm run setup` inni containeren. Etter oppsettet er ferdig lagres hele
-filsystemet til docker-bildet `vektordev:1.0`.
+This will start a new container based on `unbuntu:18.04`, install `php7.2`,
+`npm` etc., and make an empty `/app` folder. When we later start our container,
+we will mount the development directory into the `/app` folder. We don't want to
+rebuild the docker image while developing, so we simply use docker for the
+binaries, and mount in the actual folder. This means we don't even have to
+restart the container for changes to take effect.
 
-## Kjør docker-bildet
-Nå kan du kjøre docker-bildet med kommandoen
+## Running setup
+We need to get all npm and php requirements, so run
 ```
-docker run -it -p 8000:8000 vektordev:1.0
+npm run docker:dev:setup
 ```
-Denne komandoen vil starte en container fra bildet `vektordev:1.0`, og kjøre
-kommandoen `npm start` inni. Instillingene `-it` gjør at du får kontroll over
-terminalen inni containeren, og kan bruke Ctrl-C for å skru av serveren.
-Instillingen `-p 8000:8000` gjør at nettverksporten `8000` blir tilgjengelig
-også utenfor containeren, f.eks. i nettleseren.
+This will run `npm run setup` inside a docker container based on the
+`vektordev:1.0` image, but the setup will happen in the `vektorprogrammet/`
+folder on the host machine. `vektorprogrammet/` is mounted into `app/` in the
+container.
 
-Sjekk i terminalen at alt ser funksjonelt ut, og åpne siden i nettleseren din på
-[localhost:8000].
-
-## Gjør endringer
-Hvis du nå gjør endringer i databasen
+## Running the server
+To start the server, simply run
+```
+npm run docker:dev:start
+```
+This will run `npm start` in a new container, but the server will still run from
+the the `vektorprogrammet/` folder on the host machine. This means the server
+will behave as if there were no container. The port `8000` is passed through the
+container to the host machine, so open [0.0.0.0:8000] to access the server
+normally.

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,35 @@
+# Bruk av Docker
+Ved å bruke docker slipper du å installere programmer og sette opp systemet ditt
+med riktige versjoner og konfigurasjoner av php og slik. Docker lar deg bygge et
+*image*, som er et viritruelt filsystem der akkurat de riktige programmene er
+installert. Dette bildet kan så startes som en *container*, og vektorprogrammets
+server kan kjøres inni den containeren.
+
+## Lag docker-bildet
+I repoet ligger `/Dockerfile`, som beskriver hvilke kommandoer som skal
+kjøres for å omdanne en fersk installasjon av `ubuntu 18.04` til en velsmurt
+vektorprogrammet-utviklings-server.
+```
+npm run docker:dev:build
+```
+Dette vil starte en ny container, installere `php7.2`, `npm` osv, og kopiere
+all vektorprogrammet-koden inn i det viritruelle filsystemet. Deretter kjøres
+`npm run setup` inni containeren. Etter oppsettet er ferdig lagres hele
+filsystemet til docker-bildet `vektordev:1.0`.
+
+## Kjør docker-bildet
+Nå kan du kjøre docker-bildet med kommandoen
+```
+docker run -it -p 8000:8000 vektordev:1.0
+```
+Denne komandoen vil starte en container fra bildet `vektordev:1.0`, og kjøre
+kommandoen `npm start` inni. Instillingene `-it` gjør at du får kontroll over
+terminalen inni containeren, og kan bruke Ctrl-C for å skru av serveren.
+Instillingen `-p 8000:8000` gjør at nettverksporten `8000` blir tilgjengelig
+også utenfor containeren, f.eks. i nettleseren.
+
+Sjekk i terminalen at alt ser funksjonelt ut, og åpne siden i nettleseren din på
+[localhost:8000].
+
+## Gjør endringer
+Hvis du nå gjør endringer i databasen

--- a/docker.md
+++ b/docker.md
@@ -25,7 +25,7 @@ npm run docker:dev:setup
 ```
 This will run `npm run setup` inside a docker container based on the
 `vektordev:1.0` image, but the setup will happen in the `vektorprogrammet/`
-folder on the host machine.
+folder on the host machine. Note that this might create files owned by root
 
 ## Running the server
 To start the server, simply run

--- a/docker.md
+++ b/docker.md
@@ -38,6 +38,17 @@ behave as if there were no container. The port `8000` is passed through the
 container to the host machine, so open [0.0.0.0:8000] to access the server 
 normally.
 
+## Running tests
+To run all tests, run
+```
+npm run docker:dev:test
+```
+
+To run only a specific test, find the path and run like so
+```
+npm run docker:dev:test -- -- tests/PATH/TO/TEST
+```
+
 ## Running other commands
 Sometimes you may want to run other commands, like
 * `npm run dp:update` to update the database and reload fixtures

--- a/package.json
+++ b/package.json
@@ -55,7 +55,12 @@
     "code-style": "./bin/php-cs-fixer fix src/ --dry-run --diff -vv",
     "code-style:win": ".\\bin\\php-cs-fixer fix src/ --dry-run --diff -vv",
     "cs": "./bin/php-cs-fixer fix src/ -vv || .\\bin\\php-cs-fixer fix src/ -vv",
-    "cs:win": ".\\bin\\php-cs-fixer fix src/ -vv"
+    "cs:win": ".\\bin\\php-cs-fixer fix src/ -vv",
+    "docker:dev:build": "docker image build -t vektordev:1.0 .",
+    "docker:dev:getvar": "docker create -ti --name vektordummy vektordev:1.0 true && rm -rf var && docker cp vektordummy:/app/var . && docker rm -f vektordummy",
+    "docker:dev:run": "docker run -ti --name vektorrom -p 8000:8000 --mount type=bind,src=\"$(pwd)/src\",dst=/app/src --mount type=bind,src=\"$(pwd)/var\",dst=/app/var vektordev:1.0 ; true",
+    "docker:dev:stop": "docker stop vektorrom && docker rm -f vektorrom",
+    "docker:dev:start": "npm run docker:dev:run ; echo 'Stopping vektor docker' && npm run docker:dev:stop"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,8 @@
     "cs": "./bin/php-cs-fixer fix src/ -vv || .\\bin\\php-cs-fixer fix src/ -vv",
     "cs:win": ".\\bin\\php-cs-fixer fix src/ -vv",
     "docker:dev:build": "docker image build -t vektordev:1.0 .",
-    "docker:dev:getvar": "docker create -ti --name vektordummy vektordev:1.0 true && rm -rf var && docker cp vektordummy:/app/var . && docker rm -f vektordummy",
-    "docker:dev:run": "docker run -ti --name vektorrom -p 8000:8000 --mount type=bind,src=\"$(pwd)/src\",dst=/app/src --mount type=bind,src=\"$(pwd)/var\",dst=/app/var vektordev:1.0 ; true",
-    "docker:dev:stop": "docker stop vektorrom && docker rm -f vektorrom",
-    "docker:dev:start": "npm run docker:dev:run ; echo 'Stopping vektor docker' && npm run docker:dev:stop"
+    "docker:dev:setup": "docker run -ti --mount type=bind,src=\"$(pwd)\",dst=/app vektordev:1.0 npm run setup; true",
+    "docker:dev:start": "docker run -ti -p 8000:8000 --mount type=bind,src=\"$(pwd)\",dst=/app vektordev:1.0 ; true"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "cs": "./bin/php-cs-fixer fix src/ -vv || .\\bin\\php-cs-fixer fix src/ -vv",
     "cs:win": ".\\bin\\php-cs-fixer fix src/ -vv",
     "docker:dev:build": "docker image build -t vektordev:1.0 .",
-    "docker:dev:setup": "docker run -ti --mount type=bind,src=\"$(pwd)\",dst=/app vektordev:1.0 npm run setup; true",
-    "docker:dev:start": "docker run -ti -p 8000:8000 --mount type=bind,src=\"$(pwd)\",dst=/app vektordev:1.0 ; true"
+    "docker:dev:run":   "docker run -ti -p 8000:8000 --mount type=bind,src=\"$(pwd)\",dst=/app vektordev:1.0",
+    "docker:dev:setup": "npm run docker:dev:run -- npm run setup",
+    "docker:dev:start": "npm run docker:dev:run -- npm start"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "docker:dev:build": "docker image build -t vektordev:1.0 .",
     "docker:dev:run":   "docker run -ti -p 8000:8000 --mount type=bind,src=\"$(pwd)\",dst=/app vektordev:1.0",
     "docker:dev:setup": "npm run docker:dev:run -- npm run setup",
-    "docker:dev:start": "npm run docker:dev:run -- npm start"
+    "docker:dev:start": "npm run docker:dev:run -- npm start",
+    "docker:dev:test": "npm run docker:dev:run -- npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a `Dockerfile` for building a development environment image with working versions of php and node. Everything is mounted into the container upon startup, so you don't have to rebuild the image or restart the container for changes to take effect, and everything is where you would expect it to be on the host machine.

The file [`docker.md`](https://github.com/vektorprogrammet/vektorprogrammet/blob/abf1d786700121b3a2dff39b4fdc85cbe9e57999/docker.md) describes how to set up the environment and run the server. Some scripts have been added to `package.json` to make it easier:
* `npm run docker:dev:build` - Builds the image
* `npm run docker:dev:setup` - Runs `npm run setup` in a container, with the repo mounted
* `npm run docker:dev:start` - Runs `npm start` in a container, with the repo mounted
* `npm run docker:dev:run -- <your> <command> <here>` - Runs your command in a container, with the repo mounted
