### PR TITLE
Additional comment on certificates

### DIFF
--- a/app/DoctrineMigrations/Version20200406083959.php
+++ b/app/DoctrineMigrations/Version20200406083959.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200406083959 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE signature ADD additional_comment VARCHAR(500) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE signature DROP additional_comment');
+    }
+}

--- a/app/Resources/views/certificate/certificate.html.twig
+++ b/app/Resources/views/certificate/certificate.html.twig
@@ -167,7 +167,11 @@
         </div>
         <br>
         <br>
-
+        {% if additional_comment %}
+            <p>
+                {{ additional_comment }}
+            </p>
+        {% endif %}
         <p class="bold courtesy-of">På vegne av Vektorprogrammet.</p>
         <img src="{{ base_dir ~ "/../" ~ signature.signaturePath }}"
              class="signature-image"

--- a/app/Resources/views/certificate/index.html.twig
+++ b/app/Resources/views/certificate/index.html.twig
@@ -77,7 +77,7 @@
         </div>
         <div class="col-12 col-xl-6">
             <div class="card">
-                <div class="card-header"><i class="fa fa-file-signature"></i> Signatur</div>
+                <div class="card-header"><i class="fa fa-file-signature"></i> Signatur & Ekstra Kommentar</div>
                 <div class="card-body">
                     {{ form_start(form) }}
                     {{ form_errors(form) }}
@@ -92,9 +92,12 @@
                             Velg bilde
                         </button>
                     </div>
-                    <div class="mt-5">
-                        <label>Beskrivelse (Feks. Leder, Vektorprogrammet)
-                            {{ form_row(form.description) }}</label>
+                    <div class="mt-3">
+                        {{ form_row(form.description) }}
+                    </div>
+                    <br>
+                    <div class="mt-4">
+                        {{ form_row(form.additional_comment) }}
                     </div>
                     <br>
                     <button class="btn btn-primary">Lagre</button>

--- a/src/AppBundle/Controller/CertificateController.php
+++ b/src/AppBundle/Controller/CertificateController.php
@@ -59,7 +59,7 @@ class CertificateController extends BaseController
             $manager->persist($signature);
             $manager->flush();
 
-            $this->addFlash('success', 'Signaturen ble lagret');
+            $this->addFlash('success', 'Signatur og evt. kommentar ble lagret');
             return $this->redirect($request->headers->get('referer'));
         }
 

--- a/src/AppBundle/Controller/ProfileController.php
+++ b/src/AppBundle/Controller/ProfileController.php
@@ -181,17 +181,21 @@ class ProfileController extends BaseController
         // Find department
         $department = $this->getUser()->getDepartment();
 
+        // Find any additional comment
+        $additional_comment = $signature->getAdditionalComment();
+
         if ($signature === null) {
             return $this->redirectToRoute('certificate_show');
         }
 
-        $html        = $this->renderView('certificate/certificate.html.twig', array(
-            'user'             => $user,
-            'assistantHistory' => $assistantHistory,
-            'teamMembership'      => $teamMembership,
-            'signature'        => $signature,
-            'department'       => $department,
-            'base_dir'         => $this->get('kernel')->getRootDir() . '/../web' . $request->getBasePath(),
+        $html = $this->renderView('certificate/certificate.html.twig', array(
+            'user'                  => $user,
+            'assistantHistory'      => $assistantHistory,
+            'teamMembership'        => $teamMembership,
+            'signature'             => $signature,
+            'additional_comment'    => $additional_comment,
+            'department'            => $department,
+            'base_dir'              => $this->get('kernel')->getRootDir() . '/../web' . $request->getBasePath(),
         ));
         $mpdfService = $this->get('t_fox_mpdf_port.pdf');
 

--- a/src/AppBundle/Entity/Signature.php
+++ b/src/AppBundle/Entity/Signature.php
@@ -37,6 +37,12 @@ class Signature
     private $description;
 
     /**
+     * @ORM\Column(type="string", length=250, nullable=true)
+     * @Assert\Length(min = 1, max = 500, maxMessage="Kommentaren kan maks være 500 tegn."))
+     */
+    private $additional_comment;
+
+    /**
      * @ORM\OneToOne(targetEntity="User", cascade={"persist"})
      * @ORM\JoinColumn(onDelete="CASCADE")
      */
@@ -73,6 +79,24 @@ class Signature
     {
         $this->description = $description;
     }
+
+
+    /**
+     * @return string|null
+     */
+    public function getAdditionalComment(): ?string
+    {
+        return $this->additional_comment;
+    }
+
+    /**
+     * @param string $additional_comment
+     */
+    public function setAdditionalComment($additional_comment): void
+    {
+        $this->additional_comment = $additional_comment;
+    }
+
 
     /**
      * @return User

--- a/src/AppBundle/Entity/Signature.php
+++ b/src/AppBundle/Entity/Signature.php
@@ -37,7 +37,7 @@ class Signature
     private $description;
 
     /**
-     * @ORM\Column(type="string", length=250, nullable=true)
+     * @ORM\Column(type="string", length=500, nullable=true)
      * @Assert\Length(min = 1, max = 500, maxMessage="Kommentaren kan maks være 500 tegn."))
      */
     private $additional_comment;

--- a/src/AppBundle/Form/Type/CreateSignatureType.php
+++ b/src/AppBundle/Form/Type/CreateSignatureType.php
@@ -25,7 +25,7 @@ class CreateSignatureType extends AbstractType
             ))
             ->add('additional_comment', TextareaType::class, array(
                 'label' => 'Ekstra kommentar (Valgfritt, dukker opp mellom oversikt og underskrift)',
-                'required' => False,
+                'required' => false,
                 'attr' => array(
                     'maxlength' => 500,
                     'rows' => 5,

--- a/src/AppBundle/Form/Type/CreateSignatureType.php
+++ b/src/AppBundle/Form/Type/CreateSignatureType.php
@@ -2,8 +2,10 @@
 
 namespace AppBundle\Form\Type;
 
+use Ramsey\Uuid\Provider\Node\FallbackNodeProvider;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -13,13 +15,22 @@ class CreateSignatureType extends AbstractType
     {
         $builder
             ->add('description', TextType::class, array(
-                'label' => ' ',
+                'label' => 'Beskrivelse av signatur (Feks. Leder, Vektorprogrammet)',
                 'attr' => array('maxlength' => 250),
             ))
             ->add('signature_path', FileType::class, array(
                 'required' => false,
                 'data_class' => null,
                 'label' => 'Signaturbilde',
+            ))
+            ->add('additional_comment', TextareaType::class, array(
+                'label' => 'Ekstra kommentar (Valgfritt, dukker opp mellom oversikt og underskrift)',
+                'required' => False,
+                'attr' => array(
+                    'maxlength' => 500,
+                    'rows' => 5,
+                    'placeholder' => "La stå tom om ingen kommentar ønskes. \nNB: trykk lagre for at endringer skal tre i kraft."
+                ),
             ));
     }
 }

--- a/src/AppBundle/Form/Type/CreateSignatureType.php
+++ b/src/AppBundle/Form/Type/CreateSignatureType.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Form\Type;
 
-use Ramsey\Uuid\Provider\Node\FallbackNodeProvider;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;


### PR DESCRIPTION
In these corona riddled times, there has been expressed wishes to be able to add a custom comment on the certificates generated to the assistants. We wish to be able to inform of any extra ordinary situations that might have had an impact on a given assistant's history.

The Signature entity was used to house an additional_comment field that an administrative user can write and update when generating and downloading the certificates.