### PR TITLE
Update travis to use node_js v10 (same as prod)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.1
 
 node_js:
-  - 8
+  - 10
 
 before_script:
   - composer install


### PR DESCRIPTION
Travis bruker per nå nodejs 8, mens vi i prod bruker versjon 10. Her burde samme versjon brukes begge stedene.

I prod:
<img src="https://user-images.githubusercontent.com/46197518/91767669-cd6c9800-ebdc-11ea-8d4c-c561ac81b22e.png" width=650>