### PR TITLE
make getters for start/end date for admission period able to return null

### DIFF
--- a/src/AppBundle/Entity/AdmissionPeriod.php
+++ b/src/AppBundle/Entity/AdmissionPeriod.php
@@ -114,7 +114,7 @@ class AdmissionPeriod implements PeriodInterface
      *
      * @return DateTime
      */
-    public function getStartDate(): \DateTime
+    public function getStartDate(): ? \DateTime
     {
         return $this->startDate;
     }
@@ -139,7 +139,7 @@ class AdmissionPeriod implements PeriodInterface
      *
      * @return DateTime
      */
-    public function getEndDate(): \DateTime
+    public function getEndDate(): ? \DateTime
     {
         return $this->endDate;
     }

--- a/src/AppBundle/Entity/PeriodInterface.php
+++ b/src/AppBundle/Entity/PeriodInterface.php
@@ -4,6 +4,6 @@ namespace AppBundle\Entity;
 
 interface PeriodInterface
 {
-    public function getStartDate(): \DateTime;
-    public function getEndDate(): \Datetime;
+    public function getStartDate(): ? \DateTime;
+    public function getEndDate(): ? \Datetime;
 }


### PR DESCRIPTION
When trying to create a new admission period, it would result in an error.
This was because it tried to fill in the Start and End dates for the provided AdmissionPeriod in the form.
The getters did not allow for null returns, but the newly generated AdmissionPeriod object had no data for these fields.

This fix took the approach to allow the getters to return null.
Another approach would be to set default values for the generated admission period.

I thought this solution was a bit more elegant, but 🤷‍♂️ 