### PR TITLE
use empty() instead of count()>0 for empty checks

### DIFF
--- a/src/AppBundle/Entity/AccessRule.php
+++ b/src/AppBundle/Entity/AccessRule.php
@@ -235,14 +235,9 @@ class AccessRule
 
     public function isEmpty()
     {
-        $users = $this->getUsers();
-        $teams = $this->getTeams();
-        $roles = $this->getRoles();
-
-        return
-            count(is_countable($users) ? $users : array()) == 0 &&
-            count(is_countable($teams) ? $teams : array()) == 0 &&
-            count(is_countable($roles) ? $roles : array()) == 0 &&
+            empty($this->getUsers()) &&
+            empty($this->getTeams()) &&
+            empty($this->getRoles()) &&
             !$this->isForExecutiveBoard();
     }
 


### PR DESCRIPTION
Cleans up extra `is_countable()` checks not needed when we're only checking if empty.

Also adds some comments to the AccessRuleService to make it clearer what is going on.