### PR TITLE
Add test source to sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,5 +10,7 @@ sonar.sources=./src, ./app, ./client, ./tests
 
 sonar.exclusions=./app/DoctrineMigrations/**, ./app/Resources/assets/js/skins/bootstrapck/**
 
+sonar.tests=./tests/AppBundle/**
+
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sources=./src, ./app, ./client, ./tests
 
 sonar.exclusions=./app/DoctrineMigrations/**, ./app/Resources/assets/js/skins/bootstrapck/**
 
-sonar.tests=./tests/AppBundle/**
+sonar.tests=./tests/AppBundle/**/*
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
SonarCloud klager på test-coverage, noe som skjer fordi `sonar.tests` ikke er spesifisert i `sonar-project.properties`.
