### PR TITLE
Use class name in getRepo function call (instead of 'Appbundle:classname')

### DIFF
--- a/src/AppBundle/Command/SendListOfScheduledInterviewsCommand.php
+++ b/src/AppBundle/Command/SendListOfScheduledInterviewsCommand.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Command;
 
+use AppBundle\Entity\Department;
+use AppBundle\Entity\Interview;
 use AppBundle\Service\InterviewManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -38,7 +40,7 @@ class SendListOfScheduledInterviewsCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $departments = $this->em->getRepository('AppBundle:Department')->findActive();
+        $departments = $this->em->getRepository(Department::class)->findActive();
         foreach ($departments as $department) {
             $admissionPeriod = $department->getCurrentAdmissionPeriod();
             if (!$admissionPeriod) {
@@ -46,7 +48,7 @@ class SendListOfScheduledInterviewsCommand extends ContainerAwareCommand
             }
 
             $semester = $admissionPeriod->getSemester();
-            $interviewersInDepartment = $this->em->getRepository('AppBundle:Interview')->findInterviewersInSemester($semester);
+            $interviewersInDepartment = $this->em->getRepository(Interview::class)->findInterviewersInSemester($semester);
             foreach ($interviewersInDepartment as $interviewer) {
                 $this->interviewManager->sendInterviewScheduleToInterviewer($interviewer);
             }

--- a/src/AppBundle/Command/UpdateUserRolesCommand.php
+++ b/src/AppBundle/Command/UpdateUserRolesCommand.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Command;
 
+use AppBundle\Entity\User;
 use AppBundle\Service\RoleManager;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -62,7 +63,7 @@ HELP
     {
         $startTime = microtime(true);
 
-        $users = $this->entityManager->getRepository('AppBundle:User')->findAll();
+        $users = $this->entityManager->getRepository(User::class)->findAll();
 
         foreach ($users as $user) {
             $roleUpdated = $this->roleManager->updateUserRole($user);

--- a/src/AppBundle/Controller/AccessRuleController.php
+++ b/src/AppBundle/Controller/AccessRuleController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity\AccessRule;
+use AppBundle\Entity\UnhandledAccessRule;
 use AppBundle\Form\Type\AccessRuleType;
 use AppBundle\Form\Type\RoutingAccessRuleType;
 use AppBundle\Role\ReversedRoleHierarchy;
@@ -22,9 +23,9 @@ class AccessRuleController extends Controller
      */
     public function indexAction()
     {
-        $customRules = $this->getDoctrine()->getRepository('AppBundle:AccessRule')->findCustomRules();
-        $routingRules = $this->getDoctrine()->getRepository('AppBundle:AccessRule')->findRoutingRules();
-        $unhandledRules = $this->getDoctrine()->getRepository('AppBundle:UnhandledAccessRule')->findAll();
+        $customRules = $this->getDoctrine()->getRepository(AccessRule::class)->findCustomRules();
+        $routingRules = $this->getDoctrine()->getRepository(AccessRule::class)->findRoutingRules();
+        $unhandledRules = $this->getDoctrine()->getRepository(UnhandledAccessRule::class)->findAll();
         return $this->render('admin/access_rule/index.html.twig', array(
             'customRules' => $customRules,
             'routingRules' => $routingRules,

--- a/src/AppBundle/Controller/AdmissionAdminController.php
+++ b/src/AppBundle/Controller/AdmissionAdminController.php
@@ -223,7 +223,8 @@ class AdmissionAdminController extends BaseController
     public function bulkDeleteApplicationAction(Request $request)
     {
         // Get the ids from the form
-        $applicationIds = $request->request->get('application')['id'];
+        $applicationIds = array_map('intval', $request->request->get('application')['id']);
+
 
         $em = $this->getDoctrine()->getManager();
 

--- a/src/AppBundle/Controller/AdmissionAdminController.php
+++ b/src/AppBundle/Controller/AdmissionAdminController.php
@@ -2,7 +2,12 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Entity\Application;
+use AppBundle\Entity\Semester;
+use AppBundle\Entity\Team;
+use AppBundle\Entity\TeamInterest;
+use AppBundle\Entity\User;
 use AppBundle\Event\ApplicationCreatedEvent;
 use AppBundle\Form\Type\ApplicationType;
 use AppBundle\Role\Roles;
@@ -42,7 +47,7 @@ class AdmissionAdminController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
 
         $admissionPeriod = $this->getDoctrine()
-                ->getRepository('AppBundle:AdmissionPeriod')
+                ->getRepository(AdmissionPeriod::class)
                 ->findOneByDepartmentAndSemester($department, $semester);
 
         if (!$this->isGranted(Roles::TEAM_LEADER) && $this->getUser()->getDepartment() !== $department) {
@@ -52,7 +57,7 @@ class AdmissionAdminController extends BaseController
         $applications = [];
         if ($admissionPeriod !== null) {
             $applications = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findNewApplicationsByAdmissionPeriod($admissionPeriod);
         }
 
@@ -72,13 +77,13 @@ class AdmissionAdminController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         if (!$this->isGranted(Roles::TEAM_LEADER) && $this->getUser()->getDepartment() !== $department) {
             throw $this->createAccessDeniedException();
         }
 
-        $applicationRepo = $this->getDoctrine()->getRepository('AppBundle:Application');
+        $applicationRepo = $this->getDoctrine()->getRepository(Application::class);
 
         $applications = [];
         $interviewDistributions = [];
@@ -112,7 +117,7 @@ class AdmissionAdminController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         if (!$this->isGranted(Roles::TEAM_LEADER) && $this->getUser()->getDepartment() !== $department) {
             throw $this->createAccessDeniedException();
@@ -121,7 +126,7 @@ class AdmissionAdminController extends BaseController
         $applications = [];
         if ($admissionPeriod !== null) {
             $applications = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findInterviewedApplicants($admissionPeriod);
         }
 
@@ -146,7 +151,7 @@ class AdmissionAdminController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         if (!$this->isGranted(Roles::TEAM_LEADER) && $this->getUser()->getDepartment() !== $department) {
@@ -155,7 +160,7 @@ class AdmissionAdminController extends BaseController
         $applications = [];
         if ($admissionPeriod !== null) {
             $applications = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findExistingApplicants($admissionPeriod);
         }
 
@@ -224,7 +229,7 @@ class AdmissionAdminController extends BaseController
 
         // Delete the applications
         foreach ($applicationIds as $id) {
-            $application = $this->getDoctrine()->getRepository('AppBundle:Application')->find($id);
+            $application = $this->getDoctrine()->getRepository(Application::class)->find($id);
 
             if ($application !== null) {
                 $em->remove($application);
@@ -244,9 +249,9 @@ class AdmissionAdminController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
         $department = $this->getUser()->getDepartment();
-        $currentSemester = $em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $currentSemester = $em->getRepository(Semester::class)->findCurrentSemester();
         $admissionPeriod = $this->getDoctrine()
-            ->getRepository('AppBundle:AdmissionPeriod')
+            ->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $currentSemester);
         if ($admissionPeriod === null) {
             throw new BadRequestHttpException();
@@ -260,7 +265,7 @@ class AdmissionAdminController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $user = $em->getRepository('AppBundle:User')->findOneBy(array('email' => $application->getUser()->getEmail()));
+            $user = $em->getRepository(User::class)->findOneBy(array('email' => $application->getUser()->getEmail()));
             if ($user !== null) {
                 $application->setUser($user);
             }
@@ -302,7 +307,7 @@ class AdmissionAdminController extends BaseController
         $user = $this->getUser();
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         if (!$this->isGranted(Roles::ADMIN) && $user->getDepartment() !== $department) {
@@ -313,13 +318,13 @@ class AdmissionAdminController extends BaseController
         $teams = [];
         if ($admissionPeriod !== null) {
             $applicationsWithTeamInterest = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findApplicationByTeamInterestAndAdmissionPeriod($admissionPeriod);
-            $teams = $this->getDoctrine()->getRepository('AppBundle:Team')->findByTeamInterestAndAdmissionPeriod($admissionPeriod);
+            $teams = $this->getDoctrine()->getRepository(Team::class)->findByTeamInterestAndAdmissionPeriod($admissionPeriod);
         }
 
         $possibleApplicants = $this->getDoctrine()
-            ->getRepository('AppBundle:TeamInterest')
+            ->getRepository(TeamInterest::class)
             ->findBy(array('semester' => $semester, 'department' => $department));
 
         return $this->render('admission_admin/teamInterest.html.twig', array(

--- a/src/AppBundle/Controller/AdmissionPeriodController.php
+++ b/src/AppBundle/Controller/AdmissionPeriodController.php
@@ -22,7 +22,7 @@ class AdmissionPeriodController extends BaseController
     public function showByDepartmentAction(Department $department)
     {
         $admissionPeriods = $this->getDoctrine()
-            ->getRepository('AppBundle:AdmissionPeriod')
+            ->getRepository(AdmissionPeriod::class)
             ->findByDepartmentOrderedByTime($department);
 
 

--- a/src/AppBundle/Controller/AdmissionSubscriberController.php
+++ b/src/AppBundle/Controller/AdmissionSubscriberController.php
@@ -62,7 +62,7 @@ class AdmissionSubscriberController extends BaseController
         if (!$email || !$departmentId) {
             return new JsonResponse("Email or department missing", 400);
         }
-        $department = $this->getDoctrine()->getRepository('AppBundle:Department')->find($departmentId);
+        $department = $this->getDoctrine()->getRepository(Department::class)->find($departmentId);
         if (!$department) {
             return new JsonResponse("Invalid department", 400);
         }
@@ -84,7 +84,7 @@ class AdmissionSubscriberController extends BaseController
      */
     public function unsubscribeAction($code)
     {
-        $subscriber = $this->getDoctrine()->getRepository('AppBundle:AdmissionSubscriber')->findByUnsubscribeCode($code);
+        $subscriber = $this->getDoctrine()->getRepository(AdmissionSubscriber::class)->findByUnsubscribeCode($code);
         $this->addFlash('title', 'Opptaksvarsel - Avmelding');
         if (!$subscriber) {
             $this->addFlash('message', "Du vil ikke lengre motta varsler om opptak");

--- a/src/AppBundle/Controller/Api/AccountController.php
+++ b/src/AppBundle/Controller/Api/AccountController.php
@@ -37,7 +37,7 @@ class AccountController extends BaseController
         }
 
         try {
-            $user = $this->getDoctrine()->getRepository('AppBundle:User')->findByUsernameOrEmail($username);
+            $user = $this->getDoctrine()->getRepository(User::class)->findByUsernameOrEmail($username);
         } catch (NoResultException $e) {
             $response->setStatusCode(401);
             $response->setContent('Username does not exist');

--- a/src/AppBundle/Controller/ApplicationStatisticsController.php
+++ b/src/AppBundle/Controller/ApplicationStatisticsController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Service\ApplicationData;
 use AppBundle\Service\AssistantHistoryData;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +19,7 @@ class ApplicationStatisticsController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
         $admissionPeriod = $this->getDoctrine()
-            ->getRepository('AppBundle:AdmissionPeriod')
+            ->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         $assistantHistoryData = $this->get(AssistantHistoryData::class);

--- a/src/AppBundle/Controller/ArticleAdminController.php
+++ b/src/AppBundle/Controller/ArticleAdminController.php
@@ -32,7 +32,7 @@ class ArticleAdminController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
 
-        $articles = $em->getRepository('AppBundle:Article')->findAllArticles();
+        $articles = $em->getRepository(Article::class)->findAllArticles();
 
         // Uses the knp_paginator bundle to separate the articles into pages.
         $paginator  = $this->get('knp_paginator');

--- a/src/AppBundle/Controller/ArticleController.php
+++ b/src/AppBundle/Controller/ArticleController.php
@@ -2,8 +2,9 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Article;
+use AppBundle\Entity\Department;
 use Symfony\Component\HttpFoundation\Request;
+use AppBundle\Entity\Article;
 
 /**
  * ArticleController is the controller responsible for articles,
@@ -34,9 +35,9 @@ class ArticleController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
 
-        $articles = $em->getRepository('AppBundle:Article')->findAllPublishedArticles();
+        $articles = $em->getRepository(Article::class)->findAllPublishedArticles();
 
-        $departments = $em->getRepository('AppBundle:Department')->findAllDepartments();
+        $departments = $em->getRepository(Department::class)->findAllDepartments();
 
         // Uses the knp_paginator bundle to separate the articles into pages
         $paginator = $this->get('knp_paginator');
@@ -64,9 +65,9 @@ class ArticleController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
 
-        $articles = $em->getRepository('AppBundle:Article')->findAllArticlesByDepartments($department);
+        $articles = $em->getRepository(Article::class)->findAllArticlesByDepartments($department);
 
-        $departments = $em->getRepository('AppBundle:Department')->findAllDepartments();
+        $departments = $em->getRepository(Department::class)->findAllDepartments();
 
         // Uses the knp_paginator bundle to separate the articles into pages
         $paginator = $this->get('knp_paginator');
@@ -108,7 +109,7 @@ class ArticleController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
 
-        $articles = $em->getRepository('AppBundle:Article')
+        $articles = $em->getRepository(Article::class)
             ->findLatestArticles(self::NUM_OTHER_ARTICLES, $excludeId);
 
         return $this->render('article/sidebar_other.html.twig', array('articles' => $articles));
@@ -123,7 +124,7 @@ class ArticleController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
 
-        $articles = $em->getRepository('AppBundle:Article')->findStickyAndLatestArticles(self::NUM_CAROUSEL_ARTICLES);
+        $articles = $em->getRepository(Article::class)->findStickyAndLatestArticles(self::NUM_CAROUSEL_ARTICLES);
 
         return $this->render('article/carousel.html.twig', array('articles' => $articles));
     }
@@ -140,7 +141,7 @@ class ArticleController extends BaseController
     {
         $em = $this->getDoctrine()->getManager();
 
-        $articles = $em->getRepository('AppBundle:Article')->findLatestArticlesByDepartment($id, self::NUM_ADMISSION_ARTICLES);
+        $articles = $em->getRepository(Article::class)->findLatestArticlesByDepartment($id, self::NUM_ADMISSION_ARTICLES);
 
         return $this->render('article/department_news.html.twig', array('articles' => $articles));
     }

--- a/src/AppBundle/Controller/AssistantController.php
+++ b/src/AppBundle/Controller/AssistantController.php
@@ -2,8 +2,10 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Entity\Application;
 use AppBundle\Entity\Department;
+use AppBundle\Entity\Team;
 use AppBundle\Event\ApplicationCreatedEvent;
 use AppBundle\Form\Type\ApplicationType;
 use AppBundle\Service\ApplicationAdmission;
@@ -52,7 +54,7 @@ class AssistantController extends BaseController
     {
         $city = str_replace(array('æ', 'ø','å'), array('Æ','Ø','Å'), $city); // Make sqlite happy
         $department = $this->getDoctrine()
-                ->getRepository('AppBundle:Department')
+                ->getRepository(Department::class)
                 ->findOneByCityCaseInsensitive($city);
         if ($department !== null) {
             return $this->indexAction($request, $department);
@@ -91,7 +93,7 @@ class AssistantController extends BaseController
         $admissionManager = $this->get(ApplicationAdmission::class);
         $em = $this->getDoctrine()->getManager();
 
-        $departments = $em->getRepository('AppBundle:Department')->findActive();
+        $departments = $em->getRepository(Department::class)->findActive();
         $departments = $this->get(GeoLocation::class)->sortDepartmentsByDistanceFromClient($departments);
         $departmentsWithActiveAdmission = $this->get(FilterService::class)->filterDepartmentsByActiveAdmission($departments, true);
 
@@ -100,7 +102,7 @@ class AssistantController extends BaseController
             $specificDepartment = $departments[0];
         }
 
-        $teams = $em->getRepository('AppBundle:Team')->findByOpenApplicationAndDepartment($specificDepartment);
+        $teams = $em->getRepository(Team::class)->findByOpenApplicationAndDepartment($specificDepartment);
 
         $application = new Application();
 
@@ -128,7 +130,7 @@ class AssistantController extends BaseController
                     return $this->redirectToRoute('admission_existing_user');
                 }
 
-                $admissionPeriod = $em->getRepository('AppBundle:AdmissionPeriod')->findOneWithActiveAdmissionByDepartment($department);
+                $admissionPeriod = $em->getRepository(AdmissionPeriod::class)->findOneWithActiveAdmissionByDepartment($department);
 
                 //If no active admission period is found
                 if (!$admissionPeriod) {
@@ -202,7 +204,7 @@ class AssistantController extends BaseController
                 return $this->redirectToRoute('application_stand_form', ['shortName' => $department->getShortName()]);
             }
 
-            $admissionPeriod = $em->getRepository('AppBundle:AdmissionPeriod')->findOneWithActiveAdmissionByDepartment($department);
+            $admissionPeriod = $em->getRepository(AdmissionPeriod::class)->findOneWithActiveAdmissionByDepartment($department);
             $application->setAdmissionPeriod($admissionPeriod);
             $em->persist($application);
             $em->flush();

--- a/src/AppBundle/Controller/AssistantSchedulingController.php
+++ b/src/AppBundle/Controller/AssistantSchedulingController.php
@@ -2,10 +2,12 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Entity\Application;
 use AppBundle\AssistantScheduling\Assistant;
 use AppBundle\AssistantScheduling\School;
 use AppBundle\Entity\SchoolCapacity;
+use AppBundle\Entity\Semester;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class AssistantSchedulingController extends BaseController
@@ -24,10 +26,10 @@ class AssistantSchedulingController extends BaseController
     {
         $user = $this->getUser();
 
-        $currentSemester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
-        $currentAdmissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $currentSemester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
+        $currentAdmissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($user->getDepartment(), $currentSemester);
-        $applications = $this->getDoctrine()->getRepository('AppBundle:Application')->findAllAllocatableApplicationsByAdmissionPeriod($currentAdmissionPeriod);
+        $applications = $this->getDoctrine()->getRepository(Application::class)->findAllAllocatableApplicationsByAdmissionPeriod($currentAdmissionPeriod);
 
         $assistants = $this->getAssistantAvailableDays($applications);
 
@@ -90,9 +92,9 @@ class AssistantSchedulingController extends BaseController
     {
         $user = $this->getUser();
         $department = $user->getFieldOfStudy()->getDepartment();
-        $currentSemester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $currentSemester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
         $allCurrentSchoolCapacities = $this->getDoctrine()
-            ->getRepository('AppBundle:SchoolCapacity')->findByDepartmentAndSemester($department, $currentSemester);
+            ->getRepository(SchoolCapacity::class)->findByDepartmentAndSemester($department, $currentSemester);
         $schools = $this->generateSchoolsFromSchoolCapacities($allCurrentSchoolCapacities);
 
         return new JsonResponse(json_encode($schools));

--- a/src/AppBundle/Controller/BaseController.php
+++ b/src/AppBundle/Controller/BaseController.php
@@ -34,7 +34,7 @@ class BaseController extends Controller
                 $department = $this->getUser()->getDepartment();
             }
         } else {
-            $department = $this->getDoctrine()->getRepository('AppBundle:Department')->find($departmentId);
+            $department = $this->getDoctrine()->getRepository(Department::class)->find($departmentId);
         }
         return $department;
     }
@@ -49,9 +49,9 @@ class BaseController extends Controller
     {
         $semesterId = $request->query->get('semester');
         if ($semesterId === null) {
-            $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+            $semester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
         } else {
-            $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->find($semesterId);
+            $semester = $this->getDoctrine()->getRepository(Semester::class)->find($semesterId);
         }
         return $semester;
     }

--- a/src/AppBundle/Controller/BoardAndTeamController.php
+++ b/src/AppBundle/Controller/BoardAndTeamController.php
@@ -2,6 +2,10 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Department;
+use AppBundle\Entity\ExecutiveBoard;
+use AppBundle\Entity\Semester;
+use AppBundle\Entity\User;
 use AppBundle\Service\GeoLocation;
 
 class BoardAndTeamController extends BaseController
@@ -9,9 +13,9 @@ class BoardAndTeamController extends BaseController
     public function showAction()
     {
         // Find all departments
-        $departments = $this->getDoctrine()->getRepository('AppBundle:Department')->findActive();
+        $departments = $this->getDoctrine()->getRepository(Department::class)->findActive();
         $departments = $this->get(GeoLocation::class)->sortDepartmentsByDistanceFromClient($departments);
-        $board = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoard')->findBoard();
+        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
 
         $numberOfTeams = 0;
         foreach ($departments as $department) {
@@ -21,8 +25,8 @@ class BoardAndTeamController extends BaseController
         $departmentStats = array();
         /** @var \AppBundle\Entity\Department $department */
         foreach ($departments as $department) {
-            $currentSemester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
-            $userRepository = $this->getDoctrine()->getRepository('AppBundle:User');
+            $currentSemester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
+            $userRepository = $this->getDoctrine()->getRepository(User::class);
             $departmentStats[$department->getCity()] = array(
                 'numTeamMembers' => sizeof($userRepository->findUsersInDepartmentWithTeamMembershipInSemester($department, $currentSemester)),
                 'numAssistants' => sizeof($userRepository->findUsersWithAssistantHistoryInDepartmentAndSemester($department, $currentSemester)),

--- a/src/AppBundle/Controller/CertificateController.php
+++ b/src/AppBundle/Controller/CertificateController.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AssistantHistory;
+use AppBundle\Entity\CertificateRequest;
 use AppBundle\Entity\Semester;
 use AppBundle\Entity\Signature;
 use AppBundle\Form\Type\CreateSignatureType;
@@ -29,9 +31,9 @@ class CertificateController extends BaseController
         $semester = $this->getSemesterOrThrow404($request);
         $em = $this->getDoctrine()->getManager();
 
-        $assistants = $em->getRepository('AppBundle:AssistantHistory')->findByDepartmentAndSemester($department, $semester);
+        $assistants = $em->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($department, $semester);
 
-        $signature = $this->getDoctrine()->getRepository('AppBundle:Signature')->findByUser($this->getUser());
+        $signature = $this->getDoctrine()->getRepository(Signature::class)->findByUser($this->getUser());
         $oldPath = '';
         if ($signature === null) {
             $signature = new Signature();
@@ -64,7 +66,7 @@ class CertificateController extends BaseController
         }
 
         // Finds all the the certificate requests
-        $certificateRequests = $this->getDoctrine()->getRepository('AppBundle:CertificateRequest')->findAll();
+        $certificateRequests = $this->getDoctrine()->getRepository(CertificateRequest::class)->findAll();
 
         return $this->render('certificate/index.html.twig', array(
             'certificateRequests' => $certificateRequests,

--- a/src/AppBundle/Controller/ChangeLogController.php
+++ b/src/AppBundle/Controller/ChangeLogController.php
@@ -62,7 +62,7 @@ class ChangeLogController extends BaseController
     public function showAction()
     {
         $em = $this->getDoctrine()->getManager();
-        $changeLogItems = $em->getRepository('AppBundle:ChangeLogItem')->findAllOrderedByDate();
+        $changeLogItems = $em->getRepository(ChangeLogItem::class)->findAllOrderedByDate();
         $changeLogItems = array_reverse($changeLogItems);
 
         return $this->render('changelog/changelog_show_all.html.twig', array('changeLogItems' => $changeLogItems));

--- a/src/AppBundle/Controller/ContactController.php
+++ b/src/AppBundle/Controller/ContactController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity\Department;
+use AppBundle\Entity\ExecutiveBoard;
 use AppBundle\Entity\SupportTicket;
 use AppBundle\Event\SupportTicketCreatedEvent;
 use AppBundle\Form\Type\SupportTicketType;
@@ -29,13 +30,13 @@ class ContactController extends BaseController
     {
         if ($department === null) {
             $department = $this->get(GeoLocation::class)
-                ->findNearestDepartment($this->getDoctrine()->getRepository('AppBundle:Department')->findAll());
+                ->findNearestDepartment($this->getDoctrine()->getRepository(Department::class)->findAll());
         }
 
         $supportTicket = new SupportTicket();
         $supportTicket->setDepartment($department);
         $form = $this->createForm(SupportTicketType::class, $supportTicket, array(
-            'department_repository' => $this->getDoctrine()->getRepository('AppBundle:Department'),
+            'department_repository' => $this->getDoctrine()->getRepository(Department::class),
         ));
 
         $form->handleRequest($request);
@@ -49,7 +50,7 @@ class ContactController extends BaseController
             return $this->redirectToRoute('contact_department', array('id' => $supportTicket->getDepartment()->getId()));
         }
 
-        $board = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoard')->findBoard();
+        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
         $scrollToForm = $form->isSubmitted() && !$form->isValid();
 
         return $this->render('contact/index.html.twig', array(

--- a/src/AppBundle/Controller/ControlPanelController.php
+++ b/src/AppBundle/Controller/ControlPanelController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Service\SbsData;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -17,7 +18,7 @@ class ControlPanelController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
 
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         // Return the view to be rendered

--- a/src/AppBundle/Controller/ExecutiveBoardController.php
+++ b/src/AppBundle/Controller/ExecutiveBoardController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity\Department;
+use AppBundle\Entity\ExecutiveBoard;
 use AppBundle\Service\RoleManager;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -16,7 +17,7 @@ class ExecutiveBoardController extends BaseController
 {
     public function showAction()
     {
-        $board = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoard')->findBoard();
+        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
 
         return $this->render('team/team_page.html.twig', array(
             'team'  => $board,
@@ -25,8 +26,8 @@ class ExecutiveBoardController extends BaseController
 
     public function showAdminAction()
     {
-        $board = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoard')->findBoard();
-        $members = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoardMembership')->findAll();
+        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
+        $members = $this->getDoctrine()->getRepository(ExecutiveBoardMembership::class)->findAll();
         $activeMembers = [];
         $inactiveMembers = [];
         foreach ($members as $member) {
@@ -46,7 +47,7 @@ class ExecutiveBoardController extends BaseController
 
     public function addUserToBoardAction(Request $request, Department $department)
     {
-        $board = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoard')->findBoard();
+        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
 
         // Create a new TeamMembership entity
         $member = new ExecutiveBoardMembership();
@@ -93,7 +94,7 @@ class ExecutiveBoardController extends BaseController
 
     public function updateBoardAction(Request $request)
     {
-        $board = $this->getDoctrine()->getRepository('AppBundle:ExecutiveBoard')->findBoard();
+        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
 
         // Create the form
         $form = $this->createForm(CreateExecutiveBoardType::class, $board);

--- a/src/AppBundle/Controller/ExistingUserAdmissionController.php
+++ b/src/AppBundle/Controller/ExistingUserAdmissionController.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Semester;
+use AppBundle\Entity\Team;
 use AppBundle\Event\ApplicationCreatedEvent;
 use AppBundle\Form\Type\ApplicationExistingUserType;
 use AppBundle\Service\ApplicationAdmission;
@@ -32,7 +34,7 @@ class ExistingUserAdmissionController extends BaseController
         }
 
         $department = $user->getDepartment();
-        $teams = $em->getRepository('AppBundle:Team')->findActiveByDepartment($department);
+        $teams = $em->getRepository(Team::class)->findActiveByDepartment($department);
 
         $application = $admissionManager->createApplicationForExistingAssistant($user);
 
@@ -52,7 +54,7 @@ class ExistingUserAdmissionController extends BaseController
             return $this->redirectToRoute('my_page');
         }
 
-        $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $semester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
 
         return $this->render(':admission:existingUser.html.twig', array(
             'form' => $form->createView(),

--- a/src/AppBundle/Controller/FieldOfStudyController.php
+++ b/src/AppBundle/Controller/FieldOfStudyController.php
@@ -12,7 +12,7 @@ class FieldOfStudyController extends BaseController
     public function showAction()
     {
         $department = $this->getUser()->getFieldOfStudy()->getDepartment();
-        $fieldOfStudies = $this->getDoctrine()->getRepository('AppBundle:FieldOfStudy')->findByDepartment($department);
+        $fieldOfStudies = $this->getDoctrine()->getRepository(FieldOfStudy::class)->findByDepartment($department);
 
         return $this->render('field_of_study/show_all.html.twig', array(
             'fieldOfStudies' => $fieldOfStudies,

--- a/src/AppBundle/Controller/HomeController.php
+++ b/src/AppBundle/Controller/HomeController.php
@@ -2,6 +2,10 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Article;
+use AppBundle\Entity\AssistantHistory;
+use AppBundle\Entity\Department;
+use AppBundle\Entity\User;
 use AppBundle\Service\GeoLocation;
 
 class HomeController extends BaseController
@@ -9,18 +13,18 @@ class HomeController extends BaseController
     public function showAction()
     {
         $geoLocation = $this->get(GeoLocation::class);
-        $assistantsCount = count($this->getDoctrine()->getRepository('AppBundle:User')->findAssistants());
-        $teamMembersCount = count($this->getDoctrine()->getRepository('AppBundle:User')->findTeamMembers());
-        $articles = $this->getDoctrine()->getRepository('AppBundle:Article')->findStickyAndLatestArticles();
+        $assistantsCount = count($this->getDoctrine()->getRepository(User::class)->findAssistants());
+        $teamMembersCount = count($this->getDoctrine()->getRepository(User::class)->findTeamMembers());
+        $articles = $this->getDoctrine()->getRepository(Article::class)->findStickyAndLatestArticles();
 
-        $departments = $this->getDoctrine()->getRepository('AppBundle:Department')->findAll();
-        $departmentsWithActiveAdmission = $this->getDoctrine()->getRepository('AppBundle:Department')->findAllWithActiveAdmission();
+        $departments = $this->getDoctrine()->getRepository(Department::class)->findAll();
+        $departmentsWithActiveAdmission = $this->getDoctrine()->getRepository(Department::class)->findAllWithActiveAdmission();
         $departmentsWithActiveAdmission = $geoLocation->sortDepartmentsByDistanceFromClient($departmentsWithActiveAdmission);
         $closestDepartment = $geoLocation->findNearestDepartment($departments);
         $ipWasLocated = $geoLocation->findCoordinatesOfCurrentRequest();
 
-        $femaleAssistantCount = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->numFemale();
-        $maleAssistantCount = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->numMale();
+        $femaleAssistantCount = $this->getDoctrine()->getRepository(AssistantHistory::class)->numFemale();
+        $maleAssistantCount = $this->getDoctrine()->getRepository(AssistantHistory::class)->numMale();
 
         return $this->render('home/index.html.twig', [
             'assistantCount' => $assistantsCount + 600, // + Estimated number of assistants not registered in website

--- a/src/AppBundle/Controller/InterviewController.php
+++ b/src/AppBundle/Controller/InterviewController.php
@@ -4,6 +4,9 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Application;
 use AppBundle\Entity\Interview;
+use AppBundle\Entity\InterviewSchema;
+use AppBundle\Entity\Team;
+use AppBundle\Entity\User;
 use AppBundle\Event\InterviewConductedEvent;
 use AppBundle\Event\InterviewEvent;
 use AppBundle\Form\InterviewNewTimeType;
@@ -48,7 +51,7 @@ class InterviewController extends BaseController
             throw $this->createNotFoundException();
         }
         $department = $this->getUser()->getDepartment();
-        $teams = $this->getDoctrine()->getRepository('AppBundle:Team')->findActiveByDepartment($department);
+        $teams = $this->getDoctrine()->getRepository(Team::class)->findActiveByDepartment($department);
 
         if ($this->getUser() === $application->getUser()) {
             return $this->render('error/control_panel_error.html.twig', array( 'error' => 'Du kan ikke intervjue deg selv' ));
@@ -176,7 +179,7 @@ class InterviewController extends BaseController
 
         // Get the application objects
         $em = $this->getDoctrine()->getManager();
-        $applications = $em->getRepository('AppBundle:Application')->findBy(array( 'id' => $applicationIds ));
+        $applications = $em->getRepository(Application::class)->findBy(array( 'id' => $applicationIds ));
 
         // Delete the interviews
         foreach ($applications as $application) {
@@ -302,7 +305,7 @@ class InterviewController extends BaseController
             throw $this->createNotFoundException();
         }
         $em = $this->getDoctrine()->getManager();
-        $application = $em->getRepository('AppBundle:Application')->find($id);
+        $application = $em->getRepository(Application::class)->find($id);
         $user = $application->getUser();
         // Finds all the roles above admin in the hierarchy, used to populate dropdown menu with all admins
         $roles = $this->get(ReversedRoleHierarchy::class)->getParentRoles([ Roles::TEAM_MEMBER ]);
@@ -357,9 +360,9 @@ class InterviewController extends BaseController
             // Get the info from the form
             $data = $request->request->all();
             // Get objects from database
-            $interviewer = $em->getRepository('AppBundle:User')->findOneBy(array( 'id' => $data['interview']['interviewer'] ));
-            $schema = $em->getRepository('AppBundle:InterviewSchema')->findOneBy(array( 'id' => $data['interview']['interviewSchema'] ));
-            $applications = $em->getRepository('AppBundle:Application')->findBy(array( 'id' => $data['application']['id'] ));
+            $interviewer = $em->getRepository(User::class)->findOneBy(array( 'id' => $data['interview']['interviewer'] ));
+            $schema = $em->getRepository(InterviewSchema::class)->findOneBy(array( 'id' => $data['interview']['interviewSchema'] ));
+            $applications = $em->getRepository(Application::class)->findBy(array( 'id' => $data['application']['id'] ));
 
             // Update or create new interviews for all the given applications
             foreach ($applications as $application) {
@@ -561,7 +564,7 @@ class InterviewController extends BaseController
     {
         $semester = $interview->getApplication()->getSemester();
         $department = $interview->getApplication()->getDepartment();
-        $teamUsers = $this->getDoctrine()->getRepository('AppBundle:User')
+        $teamUsers = $this->getDoctrine()->getRepository(User::class)
             ->findUsersInDepartmentWithTeamMembershipInSemester($department, $semester);
         $coInterviewers = array_merge(array_diff($teamUsers, array($interview->getInterviewer(),$interview->getCoInterviewer())));
         $form = $this->createForm(AddCoInterviewerType::class, null, [

--- a/src/AppBundle/Controller/InterviewSchemaController.php
+++ b/src/AppBundle/Controller/InterviewSchemaController.php
@@ -66,7 +66,7 @@ class InterviewSchemaController extends BaseController
      */
     public function showSchemasAction()
     {
-        $schemas = $this->getDoctrine()->getRepository('AppBundle:InterviewSchema')->findAll();
+        $schemas = $this->getDoctrine()->getRepository(InterviewSchema::class)->findAll();
 
         return $this->render('interview/schemas.html.twig', array('schemas' => $schemas));
     }

--- a/src/AppBundle/Controller/MailingListController.php
+++ b/src/AppBundle/Controller/MailingListController.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Department;
 use AppBundle\Entity\Semester;
+use AppBundle\Entity\User;
 use AppBundle\Form\Type\GenerateMailingListType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -60,7 +61,7 @@ class MailingListController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $users = $this->getDoctrine()->getRepository('AppBundle:User')
+        $users = $this->getDoctrine()->getRepository(User::class)
             ->findUsersWithAssistantHistoryInDepartmentAndSemester($department, $semester);
 
         return $this->render('mailing_list/mailinglist_show.html.twig', array(
@@ -76,7 +77,7 @@ class MailingListController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $users = $this->getDoctrine()->getRepository('AppBundle:User')
+        $users = $this->getDoctrine()->getRepository(User::class)
             ->findUsersInDepartmentWithTeamMembershipInSemester($department, $semester);
 
         return $this->render('mailing_list/mailinglist_show.html.twig', array(
@@ -92,9 +93,9 @@ class MailingListController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $assistantUsers = $this->getDoctrine()->getRepository('AppBundle:User')
+        $assistantUsers = $this->getDoctrine()->getRepository(User::class)
             ->findUsersWithAssistantHistoryInDepartmentAndSemester($department, $semester);
-        $teamUsers = $this->getDoctrine()->getRepository('AppBundle:User')
+        $teamUsers = $this->getDoctrine()->getRepository(User::class)
             ->findUsersInDepartmentWithTeamMembershipInSemester($department, $semester);
         $users = array_unique(array_merge($assistantUsers, $teamUsers));
 

--- a/src/AppBundle/Controller/ParticipantHistoryController.php
+++ b/src/AppBundle/Controller/ParticipantHistoryController.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AssistantHistory;
+use AppBundle\Entity\TeamMembership;
 use AppBundle\Role\Roles;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -21,10 +23,10 @@ class ParticipantHistoryController extends BaseController
         }
 
         // Find all team memberships by department
-        $teamMemberships = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findTeamMembershipsByDepartment($department);
+        $teamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findTeamMembershipsByDepartment($department);
 
         // Find all assistantHistories by department
-        $assistantHistories = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->findByDepartmentAndSemester($department, $semester);
+        $assistantHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($department, $semester);
 
         return $this->render('participant_history/index.html.twig', array(
             'teamMemberships' => $teamMemberships,

--- a/src/AppBundle/Controller/PasswordResetController.php
+++ b/src/AppBundle/Controller/PasswordResetController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\PasswordReset;
 use AppBundle\Service\LogService;
 use AppBundle\Service\PasswordManager;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,7 +47,7 @@ class PasswordResetController extends BaseController
                 $this->get(LogService::class)->notice("Password reset rejected: Someone tried to reset the password for an inactive account: $email");
             } else {
                 $this->get(LogService::class)->info("{$passwordReset->getUser()} requested a password reset");
-                $oldPasswordResets = $this->getDoctrine()->getRepository('AppBundle:PasswordReset')->findByUser($passwordReset->getUser());
+                $oldPasswordResets = $this->getDoctrine()->getRepository(PasswordReset::class)->findByUser($passwordReset->getUser());
                 $em = $this->getDoctrine()->getManager();
 
                 foreach ($oldPasswordResets as $oldPasswordReset) {

--- a/src/AppBundle/Controller/PositionController.php
+++ b/src/AppBundle/Controller/PositionController.php
@@ -11,7 +11,7 @@ class PositionController extends BaseController
     public function showPositionsAction()
     {
         // Find all the positions
-        $positions = $this->getDoctrine()->getRepository('AppBundle:Position')->findAll();
+        $positions = $this->getDoctrine()->getRepository(Position::class)->findAll();
 
         // Return the view with suitable variables
         return $this->render('team_admin/show_positions.html.twig', array(

--- a/src/AppBundle/Controller/ProfileController.php
+++ b/src/AppBundle/Controller/ProfileController.php
@@ -2,6 +2,11 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AssistantHistory;
+use AppBundle\Entity\ExecutiveBoardMembership;
+use AppBundle\Entity\Role;
+use AppBundle\Entity\Signature;
+use AppBundle\Entity\TeamMembership;
 use AppBundle\Entity\User;
 use AppBundle\Event\UserEvent;
 use AppBundle\Form\Type\EditUserPasswordType;
@@ -29,13 +34,13 @@ class ProfileController extends BaseController
         $em = $this->getDoctrine()->getManager();
 
         // Fetch the assistant history of the user
-        $assistantHistory = $em->getRepository('AppBundle:AssistantHistory')->findByUser($user);
+        $assistantHistory = $em->getRepository(AssistantHistory::class)->findByUser($user);
 
         // Find the team history of the user
-        $teamMemberships = $em->getRepository('AppBundle:TeamMembership')->findByUser($user);
+        $teamMemberships = $em->getRepository(TeamMembership::class)->findByUser($user);
 
         // Find the executive board history of the user
-        $executiveBoardMemberships = $em->getRepository('AppBundle:ExecutiveBoardMembership')->findByUser($user);
+        $executiveBoardMemberships = $em->getRepository(ExecutiveBoardMembership::class)->findByUser($user);
 
         // Render the view
         return $this->render('profile/profile.html.twig', array(
@@ -56,19 +61,19 @@ class ProfileController extends BaseController
         $em = $this->getDoctrine()->getManager();
 
         // Find the work history of the user
-        $teamMemberships = $em->getRepository('AppBundle:TeamMembership')->findByUser($user);
+        $teamMemberships = $em->getRepository(TeamMembership::class)->findByUser($user);
 
         // Find the executive board history of the user
-        $executiveBoardMemberships = $em->getRepository('AppBundle:ExecutiveBoardMembership')->findByUser($user);
+        $executiveBoardMemberships = $em->getRepository(ExecutiveBoardMembership::class)->findByUser($user);
 
-        $isGrantedAssistant = ($this->getUser() !== null && $this->get(RoleManager::   class)->userIsGranted($this->getUser(), Roles::ASSISTANT));
+        $isGrantedAssistant = ($this->getUser() !== null && $this->get(RoleManager::class)->userIsGranted($this->getUser(), Roles::ASSISTANT));
 
         if (empty($teamMemberships) && empty($executiveBoardMemberships) && !$isGrantedAssistant) {
             throw $this->createAccessDeniedException();
         }
 
         // Fetch the assistant history of the user
-        $assistantHistory = $em->getRepository('AppBundle:AssistantHistory')->findByUser($user);
+        $assistantHistory = $em->getRepository(AssistantHistory::class)->findByUser($user);
 
         // Render the view
         return $this->render('profile/profile.html.twig', array(
@@ -148,7 +153,7 @@ class ProfileController extends BaseController
         }
 
         try {
-            $role = $this->getDoctrine()->getRepository('AppBundle:Role')->findByRoleName($roleName);
+            $role = $this->getDoctrine()->getRepository(Role::class)->findByRoleName($roleName);
             $user->setRoles(array( $role ));
 
             $em = $this->getDoctrine()->getManager();
@@ -171,13 +176,13 @@ class ProfileController extends BaseController
         $em = $this->getDoctrine()->getManager();
 
         // Fetch the assistant history of the user
-        $assistantHistory = $em->getRepository('AppBundle:AssistantHistory')->findByUser($user);
+        $assistantHistory = $em->getRepository(AssistantHistory::class)->findByUser($user);
 
         // Find the work history of the user
-        $teamMembership = $em->getRepository('AppBundle:TeamMembership')->findByUser($user);
+        $teamMembership = $em->getRepository(TeamMembership::class)->findByUser($user);
 
         // Find the signature of the user creating the certificate
-        $signature = $this->getDoctrine()->getRepository('AppBundle:Signature')->findByUser($this->getUser());
+        $signature = $this->getDoctrine()->getRepository(Signature::class)->findByUser($this->getUser());
 
         // Find department
         $department = $this->getUser()->getDepartment();

--- a/src/AppBundle/Controller/ReceiptController.php
+++ b/src/AppBundle/Controller/ReceiptController.php
@@ -20,10 +20,10 @@ class ReceiptController extends BaseController
 {
     public function showAction()
     {
-        $usersWithReceipts = $this->getDoctrine()->getRepository('AppBundle:User')->findAllUsersWithReceipts();
-        $refundedReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_REFUNDED);
-        $pendingReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_PENDING);
-        $rejectedReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_REJECTED);
+        $usersWithReceipts = $this->getDoctrine()->getRepository(User::class)->findAllUsersWithReceipts();
+        $refundedReceipts = $this->getDoctrine()->getRepository(Receipt::class)->findByStatus(Receipt::STATUS_REFUNDED);
+        $pendingReceipts = $this->getDoctrine()->getRepository(Receipt::class)->findByStatus(Receipt::STATUS_PENDING);
+        $rejectedReceipts = $this->getDoctrine()->getRepository(Receipt::class)->findByStatus(Receipt::STATUS_REJECTED);
 
         $refundedReceiptStatistics = new ReceiptStatistics($refundedReceipts);
         $totalPayoutThisYear = $refundedReceiptStatistics->totalPayoutIn((new DateTime())->format('Y'));
@@ -50,7 +50,7 @@ class ReceiptController extends BaseController
 
     public function showIndividualAction(User $user)
     {
-        $receipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByUser($user);
+        $receipts = $this->getDoctrine()->getRepository(Receipt::class)->findByUser($user);
 
         $sorter = $this->container->get(Sorter::class);
         $sorter->sortReceiptsBySubmitTime($receipts);
@@ -67,7 +67,7 @@ class ReceiptController extends BaseController
         $receipt = new Receipt();
         $receipt->setUser($this->getUser());
 
-        $receipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByUser($this->getUser());
+        $receipts = $this->getDoctrine()->getRepository(Receipt::class)->findByUser($this->getUser());
 
         $sorter = $this->container->get(Sorter::class);
         $sorter->sortReceiptsBySubmitTime($receipts);

--- a/src/AppBundle/Controller/SchoolAdminController.php
+++ b/src/AppBundle/Controller/SchoolAdminController.php
@@ -25,8 +25,8 @@ class SchoolAdminController extends BaseController
             throw $this->createAccessDeniedException();
         }
 
-        $inactiveAssistantHistories = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->findInactiveAssistantHistoriesBySchool($school);
-        $activeAssistantHistories = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->findActiveAssistantHistoriesBySchool($school);
+        $inactiveAssistantHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findInactiveAssistantHistoriesBySchool($school);
+        $activeAssistantHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findActiveAssistantHistoriesBySchool($school);
 
         return $this->render('school_admin/specific_school.html.twig', array(
             'activeAssistantHistories' => $activeAssistantHistories,
@@ -72,9 +72,9 @@ class SchoolAdminController extends BaseController
 
     public function showUsersByDepartmentSuperadminAction(Department $department)
     {
-        $activeDepartments = $this->getDoctrine()->getRepository('AppBundle:Department')->findActive();
+        $activeDepartments = $this->getDoctrine()->getRepository(Department::class)->findActive();
 
-        $users = $this->getDoctrine()->getRepository('AppBundle:User')->findAllUsersByDepartment($department);
+        $users = $this->getDoctrine()->getRepository(User::class)->findAllUsersByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('school_admin/all_users.html.twig', array(
@@ -89,13 +89,13 @@ class SchoolAdminController extends BaseController
         $user = $this->getUser();
 
         // Finds all the departments
-        $activeDepartments = $this->getDoctrine()->getRepository('AppBundle:Department')->findActive();
+        $activeDepartments = $this->getDoctrine()->getRepository(Department::class)->findActive();
 
         // Find the department of the user
         $department = $user->getFieldOfStudy()->getDepartment();
 
         // Find all the users of the department that are active
-        $users = $this->getDoctrine()->getRepository('AppBundle:User')->findAllUsersByDepartment($department);
+        $users = $this->getDoctrine()->getRepository(User::class)->findAllUsersByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('school_admin/all_users.html.twig', array(
@@ -111,9 +111,9 @@ class SchoolAdminController extends BaseController
         $department = $this->getUser()->getDepartment();
 
         // Find schools that are connected to the department of the user
-        $activeSchools = $this->getDoctrine()->getRepository('AppBundle:School')->findActiveSchoolsByDepartment($department);
+        $activeSchools = $this->getDoctrine()->getRepository(School::class)->findActiveSchoolsByDepartment($department);
 
-        $inactiveSchools = $this->getDoctrine()->getRepository('AppBundle:School')->findInactiveSchoolsByDepartment($department);
+        $inactiveSchools = $this->getDoctrine()->getRepository(School::class)->findInactiveSchoolsByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('school_admin/index.html.twig', array(
@@ -126,8 +126,8 @@ class SchoolAdminController extends BaseController
     public function showSchoolsByDepartmentAction(Department $department)
     {
         // Finds the schools for the given department
-        $activeSchools = $this->getDoctrine()->getRepository('AppBundle:School')->findActiveSchoolsByDepartment($department);
-        $inactiveSchools = $this->getDoctrine()->getRepository('AppBundle:School')->findInactiveSchoolsByDepartment($department);
+        $activeSchools = $this->getDoctrine()->getRepository(School::class)->findActiveSchoolsByDepartment($department);
+        $inactiveSchools = $this->getDoctrine()->getRepository(School::class)->findInactiveSchoolsByDepartment($department);
 
         // Renders the view with the variables
         return $this->render('school_admin/index.html.twig', array(

--- a/src/AppBundle/Controller/SecurityController.php
+++ b/src/AppBundle/Controller/SecurityController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Application;
 use AppBundle\Role\Roles;
 
 class SecurityController extends BaseController
@@ -34,7 +35,7 @@ class SecurityController extends BaseController
     {
         if ($this->get('security.authorization_checker')->isGranted(Roles::TEAM_MEMBER)) {
             return $this->redirectToRoute('control_panel');
-        } elseif ($this->getDoctrine()->getRepository('AppBundle:Application')->findActiveByUser($this->getUser())) {
+        } elseif ($this->getDoctrine()->getRepository(Application::class)->findActiveByUser($this->getUser())) {
             return $this->redirectToRoute('my_page');
         } else {
             return $this->redirectToRoute('profile');

--- a/src/AppBundle/Controller/SemesterController.php
+++ b/src/AppBundle/Controller/SemesterController.php
@@ -18,7 +18,7 @@ class SemesterController extends Controller
      */
     public function showAction()
     {
-        $semesters = $this->getDoctrine()->getRepository('AppBundle:Semester')->findAllOrderedByAge();
+        $semesters = $this->getDoctrine()->getRepository(Semester::class)->findAllOrderedByAge();
 
         return $this->render('semester_admin/index.html.twig', array(
             'semesters' => $semesters,
@@ -45,7 +45,7 @@ class SemesterController extends Controller
         // The fields of the form is checked if they contain the correct information
         if ($form->isValid()) {
             //Check if semester already exists
-            $existingSemester = $this->getDoctrine()->getManager()->getRepository('AppBundle:Semester')
+            $existingSemester = $this->getDoctrine()->getManager()->getRepository(Semester::class)
                 ->findByTimeAndYear($semester->getSemesterTime(), $semester->getYear());
 
             //Return to semester page if semester already exists

--- a/src/AppBundle/Controller/SignatureController.php
+++ b/src/AppBundle/Controller/SignatureController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Signature;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -12,7 +13,7 @@ class SignatureController extends BaseController
     {
         $user = $this->getUser();
 
-        $signature = $this->getDoctrine()->getRepository('AppBundle:Signature')->findByUser($user);
+        $signature = $this->getDoctrine()->getRepository(Signature::class)->findByUser($user);
         if ($signature === null) {
             throw new NotFoundHttpException('Signature not found');
         }

--- a/src/AppBundle/Controller/SocialEventController.php
+++ b/src/AppBundle/Controller/SocialEventController.php
@@ -21,7 +21,7 @@ class SocialEventController extends BaseController
         $semester = $this->getSemesterOrThrow404($request);
 
         $em = $this->getDoctrine()->getManager();
-        $repository = $em->getRepository('AppBundle:SocialEvent');
+        $repository = $em->getRepository(SocialEvent::class);
         $SocialEventList = $repository->findSocialEventsBySemesterAndDepartment($semester, $department);
 
 

--- a/src/AppBundle/Controller/SponsorsController.php
+++ b/src/AppBundle/Controller/SponsorsController.php
@@ -18,7 +18,7 @@ class SponsorsController extends BaseController
     public function sponsorsShowAction()
     {
         $sponsors = $this->getDoctrine()
-            ->getRepository('AppBundle:Sponsor')
+            ->getRepository(Sponsor::class)
             ->findAll();
 
         return $this->render('sponsors/sponsors_show.html.twig', array(

--- a/src/AppBundle/Controller/SsoController.php
+++ b/src/AppBundle/Controller/SsoController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\User;
 use Doctrine\ORM\NoResultException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,7 +23,7 @@ class SsoController extends BaseController
         }
 
         try {
-            $user = $this->getDoctrine()->getRepository('AppBundle:User')->findByUsernameOrEmail($username);
+            $user = $this->getDoctrine()->getRepository(User::class)->findByUsernameOrEmail($username);
         } catch (NoResultException $e) {
             $response->setStatusCode(401);
             $response->setContent('Username does not exist');

--- a/src/AppBundle/Controller/StandController.php
+++ b/src/AppBundle/Controller/StandController.php
@@ -2,6 +2,9 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
+use AppBundle\Entity\AdmissionSubscriber;
+use AppBundle\Entity\Application;
 use AppBundle\Service\AdmissionStatistics;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,18 +25,18 @@ class StandController extends BaseController
 
         $admissionStatistics = $this->get(AdmissionStatistics::class);
 
-        $subscribers = $this->getDoctrine()->getRepository('AppBundle:AdmissionSubscriber')->findFromWebByDepartment($department);
-        $subscribersInDepartmentAndSemester = $this->getDoctrine()->getRepository('AppBundle:AdmissionSubscriber')
+        $subscribers = $this->getDoctrine()->getRepository(AdmissionSubscriber::class)->findFromWebByDepartment($department);
+        $subscribersInDepartmentAndSemester = $this->getDoctrine()->getRepository(AdmissionSubscriber::class)
             ->findFromWebByDepartmentAndSemester($department, $semester);
         $subData = $admissionStatistics->generateGraphDataFromSubscribersInSemester($subscribersInDepartmentAndSemester, $semester);
 
-        $applications = $this->getDoctrine()->getRepository('AppBundle:Application')->findByDepartment($department);
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $applications = $this->getDoctrine()->getRepository(Application::class)->findByDepartment($department);
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         $applicationsInSemester = [];
         if ($admissionPeriod !== null) {
             $applicationsInSemester = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findByAdmissionPeriod($admissionPeriod);
         }
         $appData = $admissionStatistics->generateGraphDataFromApplicationsInAdmissionPeriod($applicationsInSemester, $admissionPeriod);

--- a/src/AppBundle/Controller/StaticContentController.php
+++ b/src/AppBundle/Controller/StaticContentController.php
@@ -29,7 +29,7 @@ class StaticContentController extends BaseController
         }
 
         $em = $this->getDoctrine()->getManager();
-        $content = $em->getRepository('AppBundle:StaticContent')->findOneByHtmlId($htmlId);
+        $content = $em->getRepository(StaticContent::class)->findOneByHtmlId($htmlId);
         if (!$content) {
             $content = new StaticContent();
             $content->setHtmlId($htmlId);

--- a/src/AppBundle/Controller/SubstituteController.php
+++ b/src/AppBundle/Controller/SubstituteController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
 use Symfony\Component\HttpFoundation\Request;
 use AppBundle\Entity\Application;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -24,13 +25,13 @@ class SubstituteController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
 
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         $substitutes = null;
         if ($admissionPeriod !== null) {
             $substitutes = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findSubstitutesByAdmissionPeriod($admissionPeriod);
         }
 

--- a/src/AppBundle/Controller/SurveyController.php
+++ b/src/AppBundle/Controller/SurveyController.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Semester;
 use AppBundle\Entity\Survey;
 use AppBundle\Entity\SurveyLinkClick;
 use AppBundle\Entity\SurveyNotification;
+use AppBundle\Entity\SurveyTaken;
 use AppBundle\Entity\User;
 use AppBundle\Form\Type\SurveyAdminType;
 use AppBundle\Form\Type\SurveyExecuteType;
@@ -151,7 +152,7 @@ class SurveyController extends BaseController
             $surveyTaken->removeNullAnswers();
             if ($form->isValid()) {
                 $allTakenSurveys = $em
-                    ->getRepository('AppBundle:SurveyTaken')
+                    ->getRepository(SurveyTaken::class)
                     ->findAllBySurveyAndUser($survey, $user);
 
                 if (!empty($allTakenSurveys)) {
@@ -269,7 +270,7 @@ class SurveyController extends BaseController
         $surveyClone = $survey->copy();
 
         $em = $this->getDoctrine()->getManager();
-        $currentSemester = $em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $currentSemester = $em->getRepository(Semester::class)->findCurrentSemester();
         $surveyClone->setSemester($currentSemester);
 
         if ($this->get(AccessControlService::class)->checkAccess("survey_admin")) {
@@ -314,7 +315,7 @@ class SurveyController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
 
 
-        $surveysWithDepartment = $this->getDoctrine()->getRepository('AppBundle:Survey')->findBy(
+        $surveysWithDepartment = $this->getDoctrine()->getRepository(Survey::class)->findBy(
             [
                 'semester' => $semester,
                 'department' => $department,
@@ -322,14 +323,14 @@ class SurveyController extends BaseController
             ['id' => 'DESC']
         );
         foreach ($surveysWithDepartment as $survey) {
-            $totalAnswered = count($this->getDoctrine()->getRepository('AppBundle:SurveyTaken')->findAllTakenBySurvey($survey));
+            $totalAnswered = count($this->getDoctrine()->getRepository(SurveyTaken::class)->findAllTakenBySurvey($survey));
             $survey->setTotalAnswered($totalAnswered);
         }
 
 
         $globalSurveys = array();
         if ($this->get(AccessControlService::class)->checkAccess("survey_admin")) {
-            $globalSurveys = $this->getDoctrine()->getRepository('AppBundle:Survey')->findBy(
+            $globalSurveys = $this->getDoctrine()->getRepository(Survey::class)->findBy(
                 [
                     'semester' => $semester,
                     'department' => null,
@@ -337,7 +338,7 @@ class SurveyController extends BaseController
                 ['id' => 'DESC']
             );
             foreach ($globalSurveys as $survey) {
-                $totalAnswered = count($this->getDoctrine()->getRepository('AppBundle:SurveyTaken')->findBy(array('survey' => $survey)));
+                $totalAnswered = count($this->getDoctrine()->getRepository(SurveyTaken::class)->findBy(array('survey' => $survey)));
                 $survey->setTotalAnswered($totalAnswered);
             }
         }

--- a/src/AppBundle/Controller/SurveyPopupController.php
+++ b/src/AppBundle/Controller/SurveyPopupController.php
@@ -3,6 +3,8 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Semester;
+use AppBundle\Entity\Survey;
 use AppBundle\Role\Roles;
 use AppBundle\Service\RoleManager;
 use DateTime;
@@ -21,10 +23,10 @@ class SurveyPopupController extends Controller
             $user->getLastPopUpTime()->diff(new DateTime())->days >= 1;
 
         if ($userShouldSeePopUp) {
-            $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+            $semester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
 
             $surveys = $this->getDoctrine()
-                ->getRepository('AppBundle:Survey')
+                ->getRepository(Survey::class)
                 ->findAllNotTakenByUserAndSemester($this->getUser(), $semester);
 
             if (!empty($surveys)) {

--- a/src/AppBundle/Controller/TeamAdminController.php
+++ b/src/AppBundle/Controller/TeamAdminController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Department;
 use AppBundle\Entity\Team;
 use AppBundle\Entity\TeamMembership;
+use AppBundle\Entity\Position;
 use AppBundle\Event\TeamEvent;
 use AppBundle\Event\TeamMembershipEvent;
 use AppBundle\Form\Type\CreateTeamMembershipType;
@@ -27,8 +28,8 @@ class TeamAdminController extends BaseController
         }
 
         // Find teams that are connected to the department of the user
-        $activeTeams   = $this->getDoctrine()->getRepository('AppBundle:Team')->findActiveByDepartment($department);
-        $inactiveTeams = $this->getDoctrine()->getRepository('AppBundle:Team')->findInactiveByDepartment($department);
+        $activeTeams   = $this->getDoctrine()->getRepository(Team::class)->findActiveByDepartment($department);
+        $inactiveTeams = $this->getDoctrine()->getRepository(Team::class)->findInactiveByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('team_admin/index.html.twig', array(
@@ -73,7 +74,7 @@ class TeamAdminController extends BaseController
         // Create a new TeamMembership entity
         $teamMembership = new TeamMembership();
         $teamMembership->setUser($this->getUser());
-        $teamMembership->setPosition($this->getDoctrine()->getRepository('AppBundle:Position')->findOneBy(array( 'name' => 'Medlem' )));
+        $teamMembership->setPosition($this->getDoctrine()->getRepository(Position::class)->findOneBy(array( 'name' => 'Medlem' )));
 
         // Create a new formType with the needed variables
         $form = $this->createForm(CreateTeamMembershipType::class, $teamMembership, [
@@ -107,13 +108,13 @@ class TeamAdminController extends BaseController
     public function showSpecificTeamAction(Team $team)
     {
         // Find all TeamMembership entities based on team
-        $activeTeamMemberships   = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findActiveTeamMembershipsByTeam($team);
-        $inActiveTeamMemberships = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findInactiveTeamMembershipsByTeam($team);
+        $activeTeamMemberships   = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeam($team);
+        $inActiveTeamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findInactiveTeamMembershipsByTeam($team);
         usort($activeTeamMemberships, array( $this, 'sortTeamMembershipsByEndDate' ));
         usort($inActiveTeamMemberships, array( $this, 'sortTeamMembershipsByEndDate' ));
 
         $user                      = $this->getUser();
-        $currentUserTeamMembership = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findActiveTeamMembershipsByUser($user);
+        $currentUserTeamMembership = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByUser($user);
         $isUserInTeam              = false;
         foreach ($currentUserTeamMembership as $wh) {
             if (in_array($wh, $activeTeamMemberships)) {
@@ -165,7 +166,7 @@ class TeamAdminController extends BaseController
 
                 return $this->redirect($this->generateUrl('teamadmin_show'));
             }
-            $teamMemberships = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findActiveTeamMembershipsByTeam($team);
+            $teamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeam($team);
 
             // Render the teampage as a preview
             return $this->render('team/team_page.html.twig', array(
@@ -185,7 +186,7 @@ class TeamAdminController extends BaseController
     public function showTeamsByDepartmentAction(Department $department)
     {
         // Find teams that are connected to the department of the department ID sent in by the request
-        $teams = $this->getDoctrine()->getRepository('AppBundle:Team')->findByDepartment($department);
+        $teams = $this->getDoctrine()->getRepository(Team::class)->findByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('team_admin/index.html.twig', array(

--- a/src/AppBundle/Controller/TeamApplicationController.php
+++ b/src/AppBundle/Controller/TeamApplicationController.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Team;
 use AppBundle\Entity\TeamApplication;
+use AppBundle\Entity\TeamMembership;
 use AppBundle\Event\TeamApplicationCreatedEvent;
 use AppBundle\Form\Type\TeamApplicationType;
 use AppBundle\Role\Roles;
@@ -19,7 +20,7 @@ class TeamApplicationController extends BaseController
     public function showApplicationAction(TeamApplication $application)
     {
         $user = $this->getUser();
-        $activeUserHistoriesInTeam = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findActiveTeamMembershipsByTeamAndUser($application->getTeam(), $user);
+        $activeUserHistoriesInTeam = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeamAndUser($application->getTeam(), $user);
         if (empty($activeUserHistoriesInTeam) && !$this->isGranted(Roles::TEAM_LEADER)) {
             throw new AccessDeniedException();
         }
@@ -31,9 +32,9 @@ class TeamApplicationController extends BaseController
 
     public function showAllApplicationsAction(Team $team)
     {
-        $applications = $this->getDoctrine()->getRepository('AppBundle:TeamApplication')->findByTeam($team);
+        $applications = $this->getDoctrine()->getRepository(TeamApplication::class)->findByTeam($team);
         $user = $this->getUser();
-        $activeUserHistoriesInTeam = $this->getDoctrine()->getRepository('AppBundle:TeamMembership')->findActiveTeamMembershipsByTeamAndUser($team, $user);
+        $activeUserHistoriesInTeam = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeamAndUser($team, $user);
         if (empty($activeUserHistoriesInTeam) && !$this->isGranted(Roles::TEAM_LEADER)) {
             throw new AccessDeniedException();
         }

--- a/src/AppBundle/Controller/TeamController.php
+++ b/src/AppBundle/Controller/TeamController.php
@@ -21,7 +21,7 @@ class TeamController extends BaseController
 
     public function showByDepartmentAndTeamAction($departmentCity, $teamName)
     {
-        $teams = $this->getDoctrine()->getRepository('AppBundle:Team')->findByCityAndName($departmentCity, $teamName);
+        $teams = $this->getDoctrine()->getRepository(Team::class)->findByCityAndName($departmentCity, $teamName);
         if (count($teams) !== 1) {
             throw new NotFoundHttpException('Team not found');
         }

--- a/src/AppBundle/Controller/TeamInterestController.php
+++ b/src/AppBundle/Controller/TeamInterestController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\Semester;
 use AppBundle\Event\TeamInterestCreatedEvent;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
@@ -28,7 +29,7 @@ class TeamInterestController extends BaseController
      */
     public function showTeamInterestFormAction(Department $department, Request $request)
     {
-        $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $semester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
         if ($semester === null) {
             throw new BadRequestHttpException('No current semester');
         }

--- a/src/AppBundle/Controller/TodoListController.php
+++ b/src/AppBundle/Controller/TodoListController.php
@@ -79,7 +79,7 @@ class TodoListController extends BaseController
     public function editTodoAction(TodoItem $item, Request $request)
     {
         $em = $this->getDoctrine()->getManager();
-        $currentSemester = $em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $currentSemester = $em->getRepository(Semester::class)->findCurrentSemester();
 
 
         $todoListService = $this->get(TodoListService::class);
@@ -159,7 +159,7 @@ class TodoListController extends BaseController
     {
         $semester = $this->getSemesterOrThrow404($request);
         $department = $this->getDepartmentOrThrow404($request);
-        if ($semester === $this->getDoctrine()->getManager()->getRepository('AppBundle:Semester')->findCurrentSemester()) {
+        if ($semester === $this->getDoctrine()->getManager()->getRepository(Semester::class)->findCurrentSemester()) {
             $item->setDeletedAt(new DateTime());
         } else {
             $item->setDeletedAt($semester->getStartDate());

--- a/src/AppBundle/Controller/UserAdminController.php
+++ b/src/AppBundle/Controller/UserAdminController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Department;
 use AppBundle\Entity\User;
 use AppBundle\Form\Type\CreateUserType;
+use AppBundle\Entity\Role;
 use AppBundle\Role\Roles;
 use AppBundle\Service\UserRegistration;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,7 +31,7 @@ class UserAdminController extends BaseController
 
         // The fields of the form is checked if they contain the correct information
         if ($form->isValid()) {
-            $role = $this->getDoctrine()->getRepository('AppBundle:Role')->findByRoleName(Roles::ASSISTANT);
+            $role = $this->getDoctrine()->getRepository(Role::class)->findByRoleName(Roles::ASSISTANT);
             $user->addRole($role);
 
             $em = $this->getDoctrine()->getManager();
@@ -52,13 +53,13 @@ class UserAdminController extends BaseController
     public function showAction()
     {
         // Finds all the departments
-        $activeDepartments = $this->getDoctrine()->getRepository('AppBundle:Department')->findActive();
+        $activeDepartments = $this->getDoctrine()->getRepository(Department::class)->findActive();
 
         // Finds the department for the current logged in user
         $department = $this->getUser()->getDepartment();
 
-        $activeUsers = $this->getDoctrine()->getRepository('AppBundle:User')->findAllActiveUsersByDepartment($department);
-        $inActiveUsers = $this->getDoctrine()->getRepository('AppBundle:User')->findAllInActiveUsersByDepartment($department);
+        $activeUsers = $this->getDoctrine()->getRepository(User::class)->findAllActiveUsersByDepartment($department);
+        $inActiveUsers = $this->getDoctrine()->getRepository(User::class)->findAllInActiveUsersByDepartment($department);
 
         return $this->render('user_admin/index.html.twig', array(
             'activeUsers' => $activeUsers,
@@ -71,10 +72,10 @@ class UserAdminController extends BaseController
     public function showUsersByDepartmentAction(Department $department)
     {
         // Finds all the departments
-        $activeDepartments = $this->getDoctrine()->getRepository('AppBundle:Department')->findActive();
+        $activeDepartments = $this->getDoctrine()->getRepository(Department::class)->findActive();
 
-        $activeUsers = $this->getDoctrine()->getRepository('AppBundle:User')->findAllActiveUsersByDepartment($department);
-        $inActiveUsers = $this->getDoctrine()->getRepository('AppBundle:User')->findAllInActiveUsersByDepartment($department);
+        $activeUsers = $this->getDoctrine()->getRepository(User::class)->findAllActiveUsersByDepartment($department);
+        $inActiveUsers = $this->getDoctrine()->getRepository(User::class)->findAllInActiveUsersByDepartment($department);
 
         // Renders the view with the variables
         return $this->render('user_admin/index.html.twig', array(

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -2,6 +2,10 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AdmissionPeriod;
+use AppBundle\Entity\Application;
+use AppBundle\Entity\AssistantHistory;
+use AppBundle\Entity\Semester;
 use AppBundle\Service\ApplicationManager;
 use AppBundle\Service\ContentModeManager;
 use AppBundle\Twig\Extension\RoleExtension;
@@ -22,15 +26,15 @@ class UserController extends BaseController
         $user = $this->getUser();
 
         $department = $user->getDepartment();
-        $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $semester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
         $admissionPeriod = $this->getDoctrine()
-            ->getRepository('AppBundle:AdmissionPeriod')
+            ->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         $activeApplication = null;
         if (null !== $admissionPeriod) {
             $activeApplication = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findByUserInAdmissionPeriod($user, $admissionPeriod);
         }
 
@@ -38,7 +42,7 @@ class UserController extends BaseController
         if (null !== $activeApplication) {
             $applicationStatus = $this->get(ApplicationManager::class)->getApplicationStatus($activeApplication);
         }
-        $activeAssistantHistories = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->findActiveAssistantHistoriesByUser($user);
+        $activeAssistantHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findActiveAssistantHistoriesByUser($user);
 
         return $this->render('my_page/my_page.html.twig', [
             "active_application" => $activeApplication,
@@ -57,7 +61,7 @@ class UserController extends BaseController
         if (!$this->getUser()->isActive()) {
             throw $this->createAccessDeniedException();
         }
-        $activeAssistantHistories = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->findActiveAssistantHistoriesByUser($this->getUser());
+        $activeAssistantHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findActiveAssistantHistoriesByUser($this->getUser());
         if (empty($activeAssistantHistories)) {
             throw $this->createNotFoundException();
         }
@@ -66,7 +70,7 @@ class UserController extends BaseController
         $partnerCount = 0;
 
         foreach ($activeAssistantHistories as $activeHistory) {
-            $schoolHistories = $this->getDoctrine()->getRepository('AppBundle:AssistantHistory')->findActiveAssistantHistoriesBySchool($activeHistory->getSchool());
+            $schoolHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findActiveAssistantHistoriesBySchool($activeHistory->getSchool());
             $partners = [];
 
             foreach ($schoolHistories as $sh) {
@@ -89,7 +93,7 @@ class UserController extends BaseController
             ];
         }
 
-        $semester = $this->getDoctrine()->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $semester = $this->getDoctrine()->getRepository(Semester::class)->findCurrentSemester();
         return $this->render('user/my_partner.html.twig', [
             'partnerInformations' => $partnerInformations,
             'partnerCount' => $partnerCount,

--- a/src/AppBundle/Controller/UserGroupCollectionController.php
+++ b/src/AppBundle/Controller/UserGroupCollectionController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\AssistantHistory;
 use AppBundle\Entity\UserGroupCollection;
 use AppBundle\Form\Type\UserGroupCollectionType;
 use AppBundle\Service\UserGroupCollectionManager;
@@ -21,7 +22,7 @@ class UserGroupCollectionController extends BaseController
 
         $em = $this->getDoctrine()->getManager();
         $bolkNames = $em
-            ->getRepository('AppBundle:AssistantHistory')
+            ->getRepository(AssistantHistory::class)
             ->findAllBolkNames();
 
 

--- a/src/AppBundle/Controller/WidgetController.php
+++ b/src/AppBundle/Controller/WidgetController.php
@@ -2,8 +2,13 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Feedback;
+use AppBundle\Entity\AdmissionPeriod;
+use AppBundle\Entity\Application;
+use AppBundle\Entity\ChangeLogItem;
 use AppBundle\Entity\Receipt;
+use AppBundle\Entity\Feedback;
+use AppBundle\Entity\Survey;
+use AppBundle\Entity\User;
 use AppBundle\Form\Type\FeedbackType;
 use AppBundle\Service\AdmissionStatistics;
 use AppBundle\Service\Sorter;
@@ -21,12 +26,12 @@ class WidgetController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         $applicationsAssignedToUser = [];
 
         if ($admissionPeriod !== null) {
-            $applicationRepo = $this->getDoctrine()->getRepository('AppBundle:Application');
+            $applicationRepo = $this->getDoctrine()->getRepository(Application::class);
             $applicationsAssignedToUser = $applicationRepo->findAssignedByUserAndAdmissionPeriod($this->getUser(), $admissionPeriod);
         }
 
@@ -35,13 +40,13 @@ class WidgetController extends BaseController
 
     public function receiptsAction()
     {
-        $usersWithReceipts = $this->getDoctrine()->getRepository('AppBundle:User')->findAllUsersWithReceipts();
+        $usersWithReceipts = $this->getDoctrine()->getRepository(User::class)->findAllUsersWithReceipts();
         $sorter = $this->container->get(Sorter::class);
 
         $sorter->sortUsersByReceiptSubmitTime($usersWithReceipts);
         $sorter->sortUsersByReceiptStatus($usersWithReceipts);
 
-        $pendingReceipts = $this->getDoctrine()->getRepository('AppBundle:Receipt')->findByStatus(Receipt::STATUS_PENDING);
+        $pendingReceipts = $this->getDoctrine()->getRepository(Receipt::class)->findByStatus(Receipt::STATUS_PENDING);
         $pendingReceiptStatistics = new ReceiptStatistics($pendingReceipts);
 
         $hasReceipts = !empty($pendingReceipts);
@@ -64,12 +69,12 @@ class WidgetController extends BaseController
 
         $admissionStatistics = $this->get(AdmissionStatistics::class);
 
-        $admissionPeriod = $this->getDoctrine()->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         $applicationsInSemester = [];
         if ($admissionPeriod !== null) {
             $applicationsInSemester = $this->getDoctrine()
-                ->getRepository('AppBundle:Application')
+                ->getRepository(Application::class)
                 ->findByAdmissionPeriod($admissionPeriod);
         }
         $appData = $admissionStatistics->generateCumulativeGraphDataFromApplicationsInAdmissionPeriod($applicationsInSemester, $admissionPeriod);
@@ -90,7 +95,7 @@ class WidgetController extends BaseController
         $semester = $this->getSemesterOrThrow404($request);
 
         $surveys = $this->getDoctrine()
-            ->getRepository('AppBundle:Survey')
+            ->getRepository(Survey::class)
             ->findAllNotTakenByUserAndSemester($this->getUser(), $semester);
 
 
@@ -101,7 +106,7 @@ class WidgetController extends BaseController
 
     public function changelogAction()
     {
-        $changeLogItems = $this->getDoctrine()->getRepository('AppBundle:ChangeLogItem')->findAllOrderedByDate();
+        $changeLogItems = $this->getDoctrine()->getRepository(ChangeLogItem::class)->findAllOrderedByDate();
         $changeLogItems = array_reverse($changeLogItems);
 
         return $this->render('widgets/changelog_widget.html.twig', [

--- a/src/AppBundle/EventSubscriber/AssistantHistorySubscriber.php
+++ b/src/AppBundle/EventSubscriber/AssistantHistorySubscriber.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\EventSubscriber;
 
+use AppBundle\Entity\Semester;
 use AppBundle\Event\AssistantHistoryCreatedEvent;
 use AppBundle\Service\UserRegistration;
 use Doctrine\ORM\EntityManagerInterface;
@@ -61,7 +62,7 @@ class AssistantHistorySubscriber implements EventSubscriberInterface
             $this->em->persist($user);
             $this->em->flush();
         } else { // Send new user code for user to create user name and password
-            $currentSemester = $this->em->getRepository('AppBundle:Semester')
+            $currentSemester = $this->em->getRepository(Semester::class)
                 ->findCurrentSemester();
 
             // Send new user code only if assistant history is added to current semester

--- a/src/AppBundle/EventSubscriber/DbSubscriber.php
+++ b/src/AppBundle/EventSubscriber/DbSubscriber.php
@@ -8,6 +8,7 @@ use AppBundle\Entity\InterviewQuestion;
 use AppBundle\Entity\InterviewQuestionAlternative;
 use AppBundle\Entity\InterviewScore;
 use AppBundle\Entity\PasswordReset;
+use AppBundle\Entity\Role;
 use AppBundle\Entity\SurveyAnswer;
 use AppBundle\Entity\SurveyQuestion;
 use AppBundle\Entity\SurveyQuestionAlternative;
@@ -77,7 +78,7 @@ class DbSubscriber implements EventSubscriber
             return;
         }
 
-        $defaultRole = $this->manager->getRepository('AppBundle:Role')->findByRoleName(Roles::ASSISTANT);
+        $defaultRole = $this->manager->getRepository(Role::class)->findByRoleName(Roles::ASSISTANT);
         $user->addRole($defaultRole);
     }
 

--- a/src/AppBundle/Service/AccessControlService.php
+++ b/src/AppBundle/Service/AccessControlService.php
@@ -42,7 +42,7 @@ class AccessControlService
 
     private function preloadCache()
     {
-        $accessRules = $this->entityManager->getRepository('AppBundle:AccessRule')->findAll();
+        $accessRules = $this->entityManager->getRepository(AccessRule::class)->findAll();
         foreach ($accessRules as $rule) {
             $key = $this->getKey($rule->getResource(), $rule->getMethod());
             if (!key_exists($key, $this->accessRulesCache)) {
@@ -51,7 +51,7 @@ class AccessControlService
             $this->accessRulesCache[$key][] = $rule;
         }
 
-        $unhandledRules = $this->entityManager->getRepository('AppBundle:UnhandledAccessRule')->findAll();
+        $unhandledRules = $this->entityManager->getRepository(UnhandledAccessRule::class)->findAll();
         foreach ($unhandledRules as $rule) {
             $key = $this->getKey($rule->getResource(), $rule->getMethod());
             if (!key_exists($key, $this->unhandledRulesCache)) {
@@ -64,7 +64,7 @@ class AccessControlService
     public function createRule(AccessRule $accessRule)
     {
         $em             = $this->entityManager;
-        $unhandledRules = $em->getRepository('AppBundle:UnhandledAccessRule')->findByResourceAndMethod($accessRule->getResource(), $accessRule->getMethod());
+        $unhandledRules = $em->getRepository(UnhandledAccessRule::class)->findByResourceAndMethod($accessRule->getResource(), $accessRule->getMethod());
         foreach ($unhandledRules as $unhandledRule) {
             $em->remove($unhandledRule);
         }

--- a/src/AppBundle/Service/AdmissionNotifier.php
+++ b/src/AppBundle/Service/AdmissionNotifier.php
@@ -4,7 +4,9 @@
 namespace AppBundle\Service;
 
 use AppBundle\Entity\AdmissionNotification;
+use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Entity\AdmissionSubscriber;
+use AppBundle\Entity\Application;
 use AppBundle\Entity\Department;
 use AppBundle\Entity\Semester;
 use DateTime;
@@ -42,7 +44,7 @@ class AdmissionNotifier
      */
     public function createSubscription(Department $department, string $email, bool $infoMeeting = false, bool $fromApplication = false)
     {
-        $alreadySubscribed = $this->em->getRepository('AppBundle:AdmissionSubscriber')->findByEmailAndDepartment($email, $department);
+        $alreadySubscribed = $this->em->getRepository(AdmissionSubscriber::class)->findByEmailAndDepartment($email, $department);
         if ($alreadySubscribed) {
             return;
         }
@@ -64,17 +66,17 @@ class AdmissionNotifier
 
     public function sendAdmissionNotifications()
     {
-        $departments = $this->em->getRepository('AppBundle:Department')->findActive();
-        $semester = $this->em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $departments = $this->em->getRepository(Department::class)->findActive();
+        $semester = $this->em->getRepository(Semester::class)->findCurrentSemester();
         try {
             foreach ($departments as $department) {
-                $admissionPeriod = $this->em->getRepository('AppBundle:AdmissionPeriod')->findOneByDepartmentAndSemester($department, $semester);
+                $admissionPeriod = $this->em->getRepository(AdmissionPeriod::class)->findOneByDepartmentAndSemester($department, $semester);
                 if ($admissionPeriod === null || !$admissionPeriod->hasActiveAdmission()) {
                     continue;
                 }
-                $applicationEmails = $this->em->getRepository('AppBundle:Application')->findEmailsByAdmissionPeriod($admissionPeriod);
-                $subscribers = $this->em->getRepository('AppBundle:AdmissionSubscriber')->findByDepartment($department);
-                $notificationEmails = $this->em->getRepository('AppBundle:AdmissionNotification')->findEmailsBySemesterAndDepartment($semester, $department);
+                $applicationEmails = $this->em->getRepository(Application::class)->findEmailsByAdmissionPeriod($admissionPeriod);
+                $subscribers = $this->em->getRepository(AdmissionSubscriber::class)->findByDepartment($department);
+                $notificationEmails = $this->em->getRepository(AdmissionNotification::class)->findEmailsBySemesterAndDepartment($semester, $department);
 
                 $notificationsSent = 0;
                 foreach ($subscribers as $subscriber) {
@@ -121,19 +123,19 @@ class AdmissionNotifier
 
     public function sendInfoMeetingNotifications()
     {
-        $departments = $this->em->getRepository('AppBundle:Department')->findActive();
-        $semester = $this->em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $departments = $this->em->getRepository(Department::class)->findActive();
+        $semester = $this->em->getRepository(Semester::class)->findCurrentSemester();
         try {
             foreach ($departments as $department) {
-                $admissionPeriod = $this->em->getRepository('AppBundle:AdmissionPeriod')->findOneByDepartmentAndSemester($department, $semester);
+                $admissionPeriod = $this->em->getRepository(AdmissionPeriod::class)->findOneByDepartmentAndSemester($department, $semester);
 
                 if ($admissionPeriod === null || !$admissionPeriod->shouldSendInfoMeetingNotifications()) {
                     continue;
                 }
 
-                $applicationEmails = $this->em->getRepository('AppBundle:Application')->findEmailsByAdmissionPeriod($admissionPeriod);
-                $subscribers = $this->em->getRepository('AppBundle:AdmissionSubscriber')->findByDepartment($department);
-                $notificationEmails = $this->em->getRepository('AppBundle:AdmissionNotification')
+                $applicationEmails = $this->em->getRepository(Application::class)->findEmailsByAdmissionPeriod($admissionPeriod);
+                $subscribers = $this->em->getRepository(AdmissionSubscriber::class)->findByDepartment($department);
+                $notificationEmails = $this->em->getRepository(AdmissionNotification::class)
                     ->findEmailsBySemesterAndDepartmentAndInfoMeeting($semester, $department);
 
                 $notificationsSent = 0;

--- a/src/AppBundle/Service/ApplicationAdmission.php
+++ b/src/AppBundle/Service/ApplicationAdmission.php
@@ -5,6 +5,8 @@ namespace AppBundle\Service;
 use AppBundle\Entity\AdmissionPeriod;
 use AppBundle\Entity\Application;
 use AppBundle\Entity\Department;
+use AppBundle\Entity\Interview;
+use AppBundle\Entity\Role;
 use AppBundle\Entity\User;
 use AppBundle\Role\Roles;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,14 +37,14 @@ class ApplicationAdmission
 
     public function createApplicationForExistingAssistant(User $user): Application
     {
-        $admissionPeriod = $this->em->getRepository('AppBundle:AdmissionPeriod')->findOneWithActiveAdmissionByDepartment($user->getDepartment());
+        $admissionPeriod = $this->em->getRepository(AdmissionPeriod::class)->findOneWithActiveAdmissionByDepartment($user->getDepartment());
 
-        $application = $this->em->getRepository('AppBundle:Application')->findByUserInAdmissionPeriod($user, $admissionPeriod);
+        $application = $this->em->getRepository(Application::class)->findByUserInAdmissionPeriod($user, $admissionPeriod);
         if ($application === null) {
             $application = new Application();
         }
 
-        $lastInterview = $this->em->getRepository('AppBundle:Interview')->findLatestInterviewByUser($user);
+        $lastInterview = $this->em->getRepository(Interview::class)->findLatestInterviewByUser($user);
 
         $application->setUser($user);
         $application->setAdmissionPeriod($admissionPeriod);
@@ -62,7 +64,7 @@ class ApplicationAdmission
             return false;
         }
         $department = $fos->getDepartment();
-        $admissionPeriod = $this->em->getRepository('AppBundle:AdmissionPeriod')
+        $admissionPeriod = $this->em->getRepository(AdmissionPeriod::class)
             ->findOneWithActiveAdmissionByDepartment($department);
         if ($admissionPeriod === null) {
             return false;
@@ -72,7 +74,7 @@ class ApplicationAdmission
 
     public function userHasAlreadyAppliedInAdmissionPeriod(User $user, AdmissionPeriod $admissionPeriod)
     {
-        $existingApplications = $this->em->getRepository('AppBundle:Application')->findByEmailInAdmissionPeriod($user->getEmail(), $admissionPeriod);
+        $existingApplications = $this->em->getRepository(Application::class)->findByEmailInAdmissionPeriod($user->getEmail(), $admissionPeriod);
 
         return count($existingApplications) > 0;
     }
@@ -81,13 +83,13 @@ class ApplicationAdmission
     public function setCorrectUser(Application $application)
     {
         //Check if email belongs to an existing account and use that account
-        $user = $this->em->getRepository('AppBundle:User')->findOneBy(array('email' => $application->getUser()->getEmail()));
+        $user = $this->em->getRepository(User::class)->findOneBy(array('email' => $application->getUser()->getEmail()));
         if ($user !== null) {
             $application->setUser($user);
         }
 
         if (count($application->getUser()->getRoles()) === 0) {
-            $role = $this->em->getRepository('AppBundle:Role')->findByRoleName(Roles::ASSISTANT);
+            $role = $this->em->getRepository(Role::class)->findByRoleName(Roles::ASSISTANT);
             $application->getUser()->addRole($role);
         }
     }
@@ -104,9 +106,9 @@ class ApplicationAdmission
         $department = null;
 
         if ($departmentIdQuery !== null) {
-            $department = $this->em->getRepository('AppBundle:Department')->find($departmentIdQuery);
+            $department = $this->em->getRepository(Department::class)->find($departmentIdQuery);
         } elseif ($departmentShortNameQuery !== null) {
-            $department = $this->em->getRepository('AppBundle:Department')->findDepartmentByShortName($departmentShortNameQuery);
+            $department = $this->em->getRepository(Department::class)->findDepartmentByShortName($departmentShortNameQuery);
         }
 
         if ($department === null) {
@@ -128,7 +130,7 @@ class ApplicationAdmission
             $content = $this->twig->render('error/no_assistanthistory.html.twig', array('user' => $user));
         } else {
             $department = $user->getDepartment();
-            $admissionPeriod = $this->em->getRepository('AppBundle:AdmissionPeriod')->findOneWithActiveAdmissionByDepartment($department);
+            $admissionPeriod = $this->em->getRepository(AdmissionPeriod::class)->findOneWithActiveAdmissionByDepartment($department);
 
             if ($admissionPeriod === null) {
                 $content = $this->twig->render(':error:no_active_admission.html.twig');

--- a/src/AppBundle/Service/ApplicationData.php
+++ b/src/AppBundle/Service/ApplicationData.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Service;
 
 use AppBundle\Entity\AdmissionPeriod;
+use AppBundle\Entity\Application;
+use AppBundle\Entity\AssistantHistory;
 use AppBundle\Entity\Department;
 use AppBundle\Entity\Repository\ApplicationRepository;
 use AppBundle\Entity\User;
@@ -37,7 +39,7 @@ class ApplicationData
     public function __construct(EntityManagerInterface $em, TokenStorageInterface $ts)
     {
         $this->em = $em;
-        $this->applicationRepository = $this->em->getRepository('AppBundle:Application');
+        $this->applicationRepository = $this->em->getRepository(Application::class);
 
         if ($ts->getToken() !== null && $ts->getToken()->getUser() instanceof User) {
             $this->setDepartment($ts->getToken()->getUser()->getDepartment());
@@ -110,22 +112,22 @@ class ApplicationData
 
     public function getInterviewedAssistantsCount(): int
     {
-        return count($this->em->getRepository('AppBundle:Application')->findInterviewedApplicants($this->admissionPeriod));
+        return count($this->em->getRepository(Application::class)->findInterviewedApplicants($this->admissionPeriod));
     }
 
     public function getAssignedInterviewsCount(): int
     {
-        return count($this->em->getRepository('AppBundle:Application')->findAssignedApplicants($this->admissionPeriod));
+        return count($this->em->getRepository(Application::class)->findAssignedApplicants($this->admissionPeriod));
     }
 
     public function getTotalAssistantsCount(): int
     {
-        return count($this->em->getRepository('AppBundle:AssistantHistory')->findByDepartmentAndSemester($this->department, $this->admissionPeriod->getSemester()));
+        return count($this->em->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($this->department, $this->admissionPeriod->getSemester()));
     }
 
     public function getPositionsCount(): int
     {
-        $assistantHistories = $this->em->getRepository('AppBundle:AssistantHistory')->findByDepartmentAndSemester($this->department, $this->admissionPeriod->getSemester());
+        $assistantHistories = $this->em->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($this->department, $this->admissionPeriod->getSemester());
 
         return $this->countPositions($assistantHistories, $this->getTotalAssistantsCount());
     }

--- a/src/AppBundle/Service/AssistantHistoryData.php
+++ b/src/AppBundle/Service/AssistantHistoryData.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\AssistantHistory;
 use AppBundle\Entity\Department;
 use AppBundle\Entity\Semester;
 use Doctrine\ORM\EntityManagerInterface;
@@ -15,15 +16,15 @@ class AssistantHistoryData
 
     public function __construct(EntityManagerInterface $em, TokenStorageInterface $ts, GeoLocation $geoLocation)
     {
-        $this->assistantHistoryRepository = $em->getRepository('AppBundle:AssistantHistory');
+        $this->assistantHistoryRepository = $em->getRepository(AssistantHistory::class);
         $user = $ts->getToken()->getUser();
-        $departments = $em->getRepository('AppBundle:Department')->findAll();
+        $departments = $em->getRepository(Department::class)->findAll();
         if ($user == "anon.") {
             $this->department = $geoLocation->findNearestDepartment($departments);
         } else {
             $this->department = $ts->getToken()->getUser()->getDepartment();
         }
-        $this->semester = $em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $this->semester = $em->getRepository(Semester::class)->findCurrentSemester();
     }
 
     /**

--- a/src/AppBundle/Service/CompanyEmailMaker.php
+++ b/src/AppBundle/Service/CompanyEmailMaker.php
@@ -19,7 +19,7 @@ class CompanyEmailMaker
 
     public function setCompanyEmailFor(User $user, $blackList)
     {
-        $allCompanyEmails = $this->em->getRepository('AppBundle:User')->findAllCompanyEmails();
+        $allCompanyEmails = $this->em->getRepository(User::class)->findAllCompanyEmails();
         $allEmails = array_merge($allCompanyEmails, $blackList);
         $firstName = strtolower($this->replaceNorwegianCharacters($user->getFirstName()));
         $fullName = strtolower($this->replaceNorwegianCharacters($user->getFullName()));

--- a/src/AppBundle/Service/GeoLocation.php
+++ b/src/AppBundle/Service/GeoLocation.php
@@ -34,7 +34,7 @@ class GeoLocation
     public function __construct(string $ipinfoToken, array $ignoredAsns, EntityManagerInterface $em, SessionInterface $session, RequestStack $requestStack, LogService $logger)
     {
         $this->ipinfoToken = $ipinfoToken;
-        $this->departmentRepo = $em->getRepository('AppBundle:Department');
+        $this->departmentRepo = $em->getRepository(Department::class);
         $this->session = $session;
         $this->requestStack = $requestStack;
         $this->logger = $logger;

--- a/src/AppBundle/Service/InterviewManager.php
+++ b/src/AppBundle/Service/InterviewManager.php
@@ -155,7 +155,7 @@ class InterviewManager
      */
     public function sendRescheduleEmail(Interview $interview)
     {
-        $application = $this->em->getRepository('AppBundle:Application')->findOneBy(array('interview' => $interview));
+        $application = $this->em->getRepository(Application::class)->findOneBy(array('interview' => $interview));
         $user = $interview->getUser();
         $interviewers = array();
         $interviewers[] = $interview->getInterviewer();
@@ -214,7 +214,7 @@ class InterviewManager
 
     public function sendInterviewScheduleToInterviewer(User $interviewer)
     {
-        $interviews = $this->em->getRepository('AppBundle:Interview')->findUncompletedInterviewsByInterviewerInCurrentSemester($interviewer);
+        $interviews = $this->em->getRepository(Interview::class)->findUncompletedInterviewsByInterviewerInCurrentSemester($interviewer);
 
         $nothingMoreToDo = true;
         foreach ($interviews as $interview) {
@@ -253,7 +253,7 @@ class InterviewManager
 
     public function sendAcceptInterviewReminders()
     {
-        $interviews = $this->em->getRepository('AppBundle:Interview')->findAcceptInterviewNotificationRecipients(new DateTime());
+        $interviews = $this->em->getRepository(Interview::class)->findAcceptInterviewNotificationRecipients(new DateTime());
         /** @var Interview $interview */
         foreach ($interviews as $interview) {
             $oneDay = new \DateInterval('P1D');
@@ -317,7 +317,7 @@ class InterviewManager
      */
     public function getDefaultScheduleFormData(Interview $interview): array
     {
-        $previousScheduledInterview = $this->em->getRepository('AppBundle:Interview')
+        $previousScheduledInterview = $this->em->getRepository(Interview::class)
             ->findLastScheduledByUserInAdmissionPeriod($interview->getInterviewer(), $interview->getApplication()->getAdmissionPeriod());
         $room = null;
         $campus = null;

--- a/src/AppBundle/Service/PasswordManager.php
+++ b/src/AppBundle/Service/PasswordManager.php
@@ -4,6 +4,7 @@
 namespace AppBundle\Service;
 
 use AppBundle\Entity\PasswordReset;
+use AppBundle\Entity\User;
 use AppBundle\Mailer\MailerInterface;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
@@ -43,7 +44,7 @@ class PasswordManager
     public function resetCodeIsValid(string $resetCode): bool
     {
         $hashedResetCode = $this->hashCode($resetCode);
-        $passwordReset = $this->em->getRepository('AppBundle:PasswordReset')->findPasswordResetByHashedResetCode($hashedResetCode);
+        $passwordReset = $this->em->getRepository(PasswordReset::class)->findPasswordResetByHashedResetCode($hashedResetCode);
 
         return $passwordReset !== null && $passwordReset->getUser() !== null;
     }
@@ -51,7 +52,7 @@ class PasswordManager
     public function resetCodeHasExpired(string $resetCode): bool
     {
         $hashedResetCode = $this->hashCode($resetCode);
-        $passwordReset = $this->em->getRepository('AppBundle:PasswordReset')->findPasswordResetByHashedResetCode($hashedResetCode);
+        $passwordReset = $this->em->getRepository(PasswordReset::class)->findPasswordResetByHashedResetCode($hashedResetCode);
 
         $currentTime = new DateTime();
         $timeDifference = date_diff($passwordReset->getResetTime(), $currentTime);
@@ -59,7 +60,7 @@ class PasswordManager
         $hasExpired = $timeDifference->d > 1;
 
         if ($hasExpired) {
-            $this->em->getRepository('AppBundle:PasswordReset')->deletePasswordResetByHashedResetCode($hashedResetCode);
+            $this->em->getRepository(PasswordReset::class)->deletePasswordResetByHashedResetCode($hashedResetCode);
         }
 
         return $hasExpired;
@@ -69,7 +70,7 @@ class PasswordManager
     {
         $hashedResetCode = $this->hashCode($resetCode);
 
-        return $this->em->getRepository('AppBundle:PasswordReset')->findPasswordResetByHashedResetCode($hashedResetCode);
+        return $this->em->getRepository(PasswordReset::class)->findPasswordResetByHashedResetCode($hashedResetCode);
     }
 
     public function createPasswordResetEntity(string $email)
@@ -77,7 +78,7 @@ class PasswordManager
         $passwordReset = new PasswordReset();
 
         //Finds the user based on the email
-        $user = $this->em->getRepository('AppBundle:User')->findUserByEmail($email);
+        $user = $this->em->getRepository(User::class)->findUserByEmail($email);
 
         if ($user === null) {
             return null;

--- a/src/AppBundle/Service/RoleManager.php
+++ b/src/AppBundle/Service/RoleManager.php
@@ -2,6 +2,9 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\ExecutiveBoardMembership;
+use AppBundle\Entity\Role;
+use AppBundle\Entity\Semester;
 use AppBundle\Entity\User;
 use AppBundle\Google\GoogleUsers;
 use AppBundle\Role\Roles;
@@ -148,7 +151,7 @@ class RoleManager
 
     public function userIsInExecutiveBoard(User $user)
     {
-        $executiveBoardMembership = $this->em->getRepository('AppBundle:ExecutiveBoardMembership')->findByUser($user);
+        $executiveBoardMembership = $this->em->getRepository(ExecutiveBoardMembership::class)->findByUser($user);
 
         return !empty($executiveBoardMembership);
     }
@@ -165,7 +168,7 @@ class RoleManager
 
     private function userIsInATeam(User $user, bool $teamLeader)
     {
-        $semester = $this->em->getRepository('AppBundle:Semester')->findCurrentSemester();
+        $semester = $this->em->getRepository(Semester::class)->findCurrentSemester();
         $teamMemberships = $user->getTeamMemberships();
 
         if ($semester === null) {
@@ -191,7 +194,7 @@ class RoleManager
             return false;
         }
 
-        $role = $this->em->getRepository('AppBundle:Role')->findByRoleName($role);
+        $role = $this->em->getRepository(Role::class)->findByRoleName($role);
         $roleNeedsToUpdate = array_search($role, $user->getRoles()) === false;
 
         if ($roleNeedsToUpdate) {

--- a/src/AppBundle/Service/SlugMaker.php
+++ b/src/AppBundle/Service/SlugMaker.php
@@ -17,7 +17,7 @@ class SlugMaker
 
     public function setSlugFor(Article $article)
     {
-        $slugs = $this->em->getRepository('AppBundle:Article')->findSlugs();
+        $slugs = $this->em->getRepository(Article::class)->findSlugs();
 
         $slug = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $this->replaceCharacters($article->getTitle()))));
         $i = 2;

--- a/src/AppBundle/Service/SurveyManager.php
+++ b/src/AppBundle/Service/SurveyManager.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Semester;
 use AppBundle\Entity\Survey;
 use AppBundle\Entity\SurveyAnswer;
 use AppBundle\Entity\SurveyTaken;
+use AppBundle\Entity\TeamMembership;
 use AppBundle\Entity\User;
 use AppBundle\Utils\CsvUtil;
 use DateTime;
@@ -50,7 +51,7 @@ class SurveyManager
 
     public function predictSurveyTakenAnswers(SurveyTaken $surveyTaken): SurveyTaken
     {
-        $allTakenSurveys = $this->em->getRepository('AppBundle:SurveyTaken')->findAllTakenBySurvey($surveyTaken->getSurvey());
+        $allTakenSurveys = $this->em->getRepository(SurveyTaken::class)->findAllTakenBySurvey($surveyTaken->getSurvey());
 
         if (count($allTakenSurveys) === 0) {
             return $surveyTaken;
@@ -86,7 +87,7 @@ class SurveyManager
 
     public function getUserAffiliationOfSurveyAnswers(Survey $survey)
     {
-        $surveysTaken = $this->em->getRepository('AppBundle:SurveyTaken')->findAllTakenBySurvey($survey);
+        $surveysTaken = $this->em->getRepository(SurveyTaken::class)->findAllTakenBySurvey($survey);
         $userAffiliation = array();
         $semester = $survey->getSemester();
         if ($survey->getTargetAudience() === Survey::$TEAM_SURVEY) {
@@ -203,7 +204,7 @@ class SurveyManager
 
     private function getUserAffiliationOfUserBySemester(User $user, Semester $semester, $userAffiliation = array()) : array
     {
-        $teamMemberships = $this->em->getRepository('AppBundle:TeamMembership')->findTeamMembershipsByUserAndSemester($user, $semester);
+        $teamMemberships = $this->em->getRepository(TeamMembership::class)->findTeamMembershipsByUserAndSemester($user, $semester);
 
         foreach ($teamMemberships as $teamMembership) {
             $teamName = $teamMembership->getTeam()->getName();
@@ -222,7 +223,7 @@ class SurveyManager
     public function surveyResultToJson(Survey $survey)
     {
         $userAffiliation = $this->getUserAffiliationOfSurveyAnswers($survey);
-        $surveysTaken = $this->em->getRepository('AppBundle:SurveyTaken')->findAllTakenBySurvey($survey);
+        $surveysTaken = $this->em->getRepository(SurveyTaken::class)->findAllTakenBySurvey($survey);
 
         $title = $this->getSurveyTargetAudienceString($survey);
 
@@ -265,7 +266,7 @@ class SurveyManager
             throw new RuntimeException("Unrecognized survey target audience");
         }
 
-        $surveysTaken = $this->em->getRepository('AppBundle:SurveyTaken')->findAllTakenBySurvey($survey);
+        $surveysTaken = $this->em->getRepository(SurveyTaken::class)->findAllTakenBySurvey($survey);
 
         //Meta is the school or team the responder belongs to.
         $TARGET_AUDIENCE_COLUMN = "targetaudiencecolumn";

--- a/src/AppBundle/Service/TeamMembershipService.php
+++ b/src/AppBundle/Service/TeamMembershipService.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\Semester;
+use AppBundle\Entity\TeamMembership;
 use AppBundle\Event\TeamMembershipEvent;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -19,8 +21,8 @@ class TeamMembershipService
 
     public function updateTeamMemberships()
     {
-        $teamMemberships = $this->em->getRepository('AppBundle:TeamMembership')->findBy(array('isSuspended' => false));
-        $currentSemesterStartDate = $this->em->getRepository('AppBundle:Semester')->findCurrentSemester()->getStartDate();
+        $teamMemberships = $this->em->getRepository(TeamMembership::class)->findBy(array('isSuspended' => false));
+        $currentSemesterStartDate = $this->em->getRepository(Semester::class)->findCurrentSemester()->getStartDate();
         foreach ($teamMemberships as $teamMembership) {
             $endSemester = $teamMembership->getEndSemester();
             if ($endSemester) {

--- a/src/AppBundle/Service/TodoListService.php
+++ b/src/AppBundle/Service/TodoListService.php
@@ -43,7 +43,7 @@ class TodoListService
         if (empty($item->getTodoDeadlines())) {
             return false;
         } else {
-            $currentSemester = $this->em->getRepository('AppBundle:Semester')->findCurrentSemester();
+            $currentSemester = $this->em->getRepository(Semester::class)->findCurrentSemester();
             $deadlines = $item->getTodoDeadlines();
             return ($deadlines[0]->getSemester()->getId() == $currentSemester->getId());
         }
@@ -103,7 +103,7 @@ class TodoListService
      */
     public function hasDeadLineShortly(TodoItem $a)
     {
-        return ($a->hasShortDeadlineBySemester($this->em->getRepository('AppBundle:Semester')->findCurrentSemester()));
+        return ($a->hasShortDeadlineBySemester($this->em->getRepository(Semester::class)->findCurrentSemester()));
     }
 
     /**
@@ -180,7 +180,7 @@ class TodoListService
         $this->em->persist($todoItem);
 
         $correctSemester = empty($itemInfo->getSemester()) ?
-            $this->em->getRepository('AppBundle:Semester')->findCurrentSemester() :
+            $this->em->getRepository(Semester::class)->findCurrentSemester() :
             $itemInfo->getSemester();
 
         if ($itemInfo->getIsMandatory()) {
@@ -226,7 +226,7 @@ class TodoListService
 
         $preExistingMandatory = $itemInfo->getTodoMandatory();
         $previousMandatoryStatus = empty($preExistingMandatory) ? false : $preExistingMandatory->isMandatory();
-        $sr  = $this->em->getRepository('AppBundle:Semester');
+        $sr  = $this->em->getRepository(Semester::class);
         $currentSemester = $sr->findCurrentSemester();
 
 
@@ -348,7 +348,7 @@ class TodoListService
      */
     public function toggleCompletedItem(TodoItem $item, Semester $semester, Department $department)
     {
-        $completedItem = $this->em->getRepository('AppBundle:TodoCompleted')->findOneBy(
+        $completedItem = $this->em->getRepository(TodoCompleted::class)->findOneBy(
             array(
                 'semester' => $semester,
                 'department' => $department,
@@ -382,7 +382,7 @@ class TodoListService
      */
     public function getOrderedList(Department $department, Semester $semester)
     {
-        $repository = $this->em->getRepository('AppBundle:TodoItem');
+        $repository = $this->em->getRepository(TodoItem::class);
         $allTodoItems = $repository->findTodoListItemsBySemesterAndDepartment($semester, $department);
         $incompletedTodoItems = $this->getIncompletedTodoItems($allTodoItems, $semester, $department);
         $todoShortDeadLines = $this->getTodoItemsWithShortDeadline($incompletedTodoItems);

--- a/src/AppBundle/Service/UserGroupCollectionManager.php
+++ b/src/AppBundle/Service/UserGroupCollectionManager.php
@@ -69,7 +69,7 @@ class UserGroupCollectionManager
 
     private function findUsers(UserGroupCollection $userGroupCollection)
     {
-        $teamMembershipRepository = $this->em->getRepository('AppBundle:TeamMembership');
+        $teamMembershipRepository = $this->em->getRepository(TeamMembership::class);
 
         $teamMemberships = array();
         foreach ($userGroupCollection->getTeams() as $team) {
@@ -92,7 +92,7 @@ class UserGroupCollectionManager
         );
 
 
-        $assistantHistoryRepository = $this->em->getRepository('AppBundle:AssistantHistory');
+        $assistantHistoryRepository = $this->em->getRepository(AssistantHistory::class);
         $assistantHistories = array();
         foreach ($userGroupCollection->getAssistantsDepartments() as $department) {
             foreach ($userGroupCollection->getSemesters() as $semester) {

--- a/src/AppBundle/Service/UserRegistration.php
+++ b/src/AppBundle/Service/UserRegistration.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\Role;
 use AppBundle\Entity\User;
 use AppBundle\Mailer\MailerInterface;
 use AppBundle\Role\Roles;
@@ -72,7 +73,7 @@ class UserRegistration
     public function activateUserByNewUserCode(string $newUserCode)
     {
         $hashedNewUserCode = $this->getHashedCode($newUserCode);
-        $user = $this->em->getRepository('AppBundle:User')->findUserByNewUserCode($hashedNewUserCode);
+        $user = $this->em->getRepository(User::class)->findUserByNewUserCode($hashedNewUserCode);
         if ($user === null) {
             return null;
         }
@@ -87,7 +88,7 @@ class UserRegistration
         $user->setActive('1');
 
         if (count($user->getRoles()) === 0) {
-            $role = $this->em->getRepository('AppBundle:Role')->findByRoleName(Roles::ASSISTANT);
+            $role = $this->em->getRepository(Role::class)->findByRoleName(Roles::ASSISTANT);
             $user->addRole($role);
         }
 

--- a/src/AppBundle/Twig/Extension/DepartmentExtension.php
+++ b/src/AppBundle/Twig/Extension/DepartmentExtension.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Twig\Extension;
 
+use AppBundle\Entity\Department;
 use AppBundle\Service\GeoLocation;
 use Doctrine\ORM\EntityManagerInterface;
 use Twig\Extension\AbstractExtension;
@@ -33,13 +34,13 @@ class DepartmentExtension extends AbstractExtension
 
     public function getDepartments()
     {
-        $departments = $this->em->getRepository('AppBundle:Department')->findAll();
+        $departments = $this->em->getRepository(Department::class)->findAll();
         return $this->geoLocationService->sortDepartmentsByDistanceFromClient($departments);
     }
 
     public function getActiveDepartments()
     {
-        $departments = $this->em->getRepository('AppBundle:Department')->findActive();
+        $departments = $this->em->getRepository(Department::class)->findActive();
         return $this->geoLocationService->sortDepartmentsByDistanceFromClient($departments);
     }
 }

--- a/src/AppBundle/Twig/Extension/SemesterExtension.php
+++ b/src/AppBundle/Twig/Extension/SemesterExtension.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Twig\Extension;
 
+use AppBundle\Entity\Semester;
 use Doctrine\ORM\EntityManagerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -29,6 +30,6 @@ class SemesterExtension extends AbstractExtension
 
     public function getSemesters()
     {
-        return $this->em->getRepository('AppBundle:Semester')->findAllOrderedByAge();
+        return $this->em->getRepository(Semester::class)->findAllOrderedByAge();
     }
 }

--- a/src/AppBundle/Twig/Extension/SponsorsExtension.php
+++ b/src/AppBundle/Twig/Extension/SponsorsExtension.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Twig\Extension;
 
+use AppBundle\Entity\Sponsor;
 use Doctrine\ORM\EntityManagerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -31,7 +32,7 @@ class SponsorsExtension extends AbstractExtension
     public function getSponsors()
     {
         $sponsors = $this->doctrine
-            ->getRepository('AppBundle:Sponsor')
+            ->getRepository(Sponsor::class)
             ->findAll();
         if (!$sponsors) {
             return 'No sponsors :-(';
@@ -43,7 +44,7 @@ class SponsorsExtension extends AbstractExtension
     public function getSponsorsBySize($size)
     {
         $sponsors = $this->doctrine
-            ->getRepository('AppBundle:Sponsor')
+            ->getRepository(Sponsor::class)
             ->findBy(array('size' => $size));
         if (!$sponsors) {
             return [];

--- a/src/AppBundle/Twig/Extension/StaticContentExtension.php
+++ b/src/AppBundle/Twig/Extension/StaticContentExtension.php
@@ -35,7 +35,7 @@ class StaticContentExtension extends AbstractExtension
         }
 
         $content = $this->em
-            ->getRepository('AppBundle:StaticContent')
+            ->getRepository(StaticContent::class)
             ->findOneByHtmlId($htmlId);
         if (!$content) {
             $content = new StaticContent();

--- a/src/AppBundle/Validator/Constraints/UniqueCompanyEmailValidator.php
+++ b/src/AppBundle/Validator/Constraints/UniqueCompanyEmailValidator.php
@@ -35,8 +35,8 @@ class UniqueCompanyEmailValidator extends ConstraintValidator
         }
 
         $googleEmails = $this->googleAPI->getAllEmailsInUse();
-        $teamEmails = $this->em->getRepository('AppBundle:Team')->findAllEmails();
-        $userCompanyEmails = $this->em->getRepository('AppBundle:User')->findAllCompanyEmails();
+        $teamEmails = $this->em->getRepository(Team::class)->findAllEmails();
+        $userCompanyEmails = $this->em->getRepository(User::class)->findAllCompanyEmails();
         $allEmails = array_merge($googleEmails, $teamEmails, $userCompanyEmails);
 
         if (array_search($value, $allEmails) !== false) {

--- a/tests/AppBundle/Controller/AdmissionAdminControllerTest.php
+++ b/tests/AppBundle/Controller/AdmissionAdminControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\AppBundle\Controller;
 
+use AppBundle\Entity\Interview;
 use Tests\BaseWebTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 
@@ -241,7 +242,7 @@ class AdmissionAdminControllerTest extends BaseWebTestCase
         $kernel->boot();
         $em = $kernel->getContainer()->get('doctrine.orm.entity_manager');
 
-        $interview = $em->getRepository('AppBundle:Interview')->findByResponseCode($response_code);
+        $interview = $em->getRepository(Interview::class)->findByResponseCode($response_code);
         $this->assertEquals('Test answer', $interview->getCancelMessage());
 
         return $client;

--- a/tests/AppBundle/Controller/MailingListControllerTest.php
+++ b/tests/AppBundle/Controller/MailingListControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\AppBundle\Controller;
 
+use AppBundle\Entity\User;
 use Tests\BaseWebTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 
@@ -38,7 +39,7 @@ class MailingListControllerTest extends BaseWebTestCase
         $client->followRedirect();
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $user = $this->em->getRepository('AppBundle:User')->find($userID);
+        $user = $this->em->getRepository(User::class)->find($userID);
         $this->assertNotNull($user);
         $userEmailLength = strlen($user->getCompanyEmail());
 

--- a/tests/AppBundle/Service/AccessControlTest.php
+++ b/tests/AppBundle/Service/AccessControlTest.php
@@ -6,6 +6,10 @@ namespace Tests\AppBundle\Service;
 
 use AppBundle\Entity\AccessRule;
 use AppBundle\Entity\Repository\UnhandledAccessRuleRepository;
+use AppBundle\Entity\Role;
+use AppBundle\Entity\Team;
+use AppBundle\Entity\UnhandledAccessRule;
+use AppBundle\Entity\User;
 use AppBundle\Role\Roles;
 use AppBundle\Service\AccessControlService;
 use Tests\BaseKernelTestCase;
@@ -39,18 +43,18 @@ class AccessControlTest extends BaseKernelTestCase {
 
 		$this->service = $kernel->getContainer()->get(AccessControlService::class);
 		$em = $kernel->getContainer()->get('doctrine')->getManager();
-		$this->unhandledRepo = $em->getRepository('AppBundle:UnhandledAccessRule');
-		$this->inactiveUser = $em->getRepository('AppBundle:User')->findUserByEmail('inactive@mail.com');
-		$this->assistant = $em->getRepository('AppBundle:User')->findUserByEmail('assistant@gmail.com');
-		$this->teamMember = $em->getRepository('AppBundle:User')->findUserByEmail('marte@mail.no');
-		$this->teamMemberAndExecutiveBoardMember = $em->getRepository('AppBundle:User')->findUserByEmail('sortland@mail.com');
-		$this->inactiveTeamMember = $em->getRepository('AppBundle:User')->findUserByEmail('aai@b.c');
-		$this->executiveBoardMember = $em->getRepository('AppBundle:User')->findUserByEmail('angela@mail.no');
-		$this->inactiveExecutiveBoardMember = $em->getRepository('AppBundle:User')->findUserByEmail('jan-per-gustavio@gmail.com');
-		$this->admin = $em->getRepository('AppBundle:User')->findUserByEmail('admin@gmail.com');
-		$this->team = $em->getRepository('AppBundle:Team')->find(1);
-		$this->teamMemberRole = $em->getRepository('AppBundle:Role')->findByRoleName(Roles::TEAM_MEMBER);
-		$this->teamLeaderRole = $em->getRepository('AppBundle:Role')->findByRoleName(Roles::TEAM_LEADER);
+		$this->unhandledRepo = $em->getRepository(UnhandledAccessRule::class);
+		$this->inactiveUser = $em->getRepository(User::class)->findUserByEmail('inactive@mail.com');
+		$this->assistant = $em->getRepository(User::class)->findUserByEmail('assistant@gmail.com');
+		$this->teamMember = $em->getRepository(User::class)->findUserByEmail('marte@mail.no');
+		$this->teamMemberAndExecutiveBoardMember = $em->getRepository(User::class)->findUserByEmail('sortland@mail.com');
+		$this->inactiveTeamMember = $em->getRepository(User::class)->findUserByEmail('aai@b.c');
+		$this->executiveBoardMember = $em->getRepository(User::class)->findUserByEmail('angela@mail.no');
+		$this->inactiveExecutiveBoardMember = $em->getRepository(User::class)->findUserByEmail('jan-per-gustavio@gmail.com');
+		$this->admin = $em->getRepository(User::class)->findUserByEmail('admin@gmail.com');
+		$this->team = $em->getRepository(Team::class)->find(1);
+		$this->teamMemberRole = $em->getRepository(Role::class)->findByRoleName(Roles::TEAM_MEMBER);
+		$this->teamLeaderRole = $em->getRepository(Role::class)->findByRoleName(Roles::TEAM_LEADER);
 	}
 
 	public function testHasAccessWhenRuleDoesNotExist() {

--- a/tests/AppBundle/Service/RoleManagerTest.php
+++ b/tests/AppBundle/Service/RoleManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\AppBundle\Command;
 
+use AppBundle\Entity\User;
 use AppBundle\Role\Roles;
 use AppBundle\Service\RoleManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -78,14 +79,14 @@ class RoleManagerTest extends KernelTestCase
     private function updateAllUserRoles()
     {
         foreach ($this->mockUsers as $mockUser) {
-            $user = $this->em->getRepository('AppBundle:User')->findUserByEmail($mockUser->getEmail());
+            $user = $this->em->getRepository(User::class)->findUserByEmail($mockUser->getEmail());
             $this->roleManager->updateUserRole($user);
         }
     }
 
     private function assertThatUserWithEmailHasRole(string $email, string $role)
     {
-        $user = $this->em->getRepository('AppBundle:User')->findUserByEmail($email);
+        $user = $this->em->getRepository(User::class)->findUserByEmail($email);
         $this->assertEquals($role, current($user->getRoles())->getRole());
     }
 }

--- a/tests/AppBundle/Service/TodoListTest.php
+++ b/tests/AppBundle/Service/TodoListTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use AppBundle\Entity\Department;
+use AppBundle\Entity\Semester;
 use AppBundle\Entity\TodoItem;
 
 class TodoListTest extends \Tests\BaseKernelTestCase
@@ -20,12 +23,12 @@ class TodoListTest extends \Tests\BaseKernelTestCase
     private $completedItem;
 
     /**
-     * @var \AppBundle\Entity\Semester
+     * @var Semester
      */
     private $currentSemester;
 
     /**
-     * @var \AppBundle\Entity\Department
+     * @var Department
      */
     private $department;
 
@@ -62,11 +65,11 @@ class TodoListTest extends \Tests\BaseKernelTestCase
         $this->service = $service;
         $em = $kernel->getContainer()->get('doctrine')->getManager();
         $this->em = $em;
-        $todoRepo = $em->getRepository('AppBundle:TodoItem');
+        $todoRepo = $em->getRepository(TodoItem::class);
         $this->completedItem = $todoRepo->findOneBy(['title' => 'completedTodoItem']);
         $this->incompletedItem = $todoRepo->findOneBy(['title' => 'incompletedTodoItem']);
-        $this->currentSemester = $em->getRepository('AppBundle:Semester')->findCurrentSemester();
-        $this->department = $em->getRepository('AppBundle:Department')->findOneBy(['shortName' => 'NTNU']);
+        $this->currentSemester = $em->getRepository(Semester::class)->findCurrentSemester();
+        $this->department = $em->getRepository(Department::class)->findOneBy(['shortName' => 'NTNU']);
 
         $this->itemWithShortDeadline = $todoRepo->findOneBy(['title' => 'shortDeadlineItem']);
         $this->itemWithAlmostShortDeadline = $todoRepo->findOneBy(['title' => 'almostShortDeadlineItem']);


### PR DESCRIPTION
AppBundle fases ut fra Symfony 4. Denne PRen endrer input-parameter til "getRepository", for å ikke bruke AppBundle.

--
Edit:
Ser at Sonar klager på eksisterende mangler. Dessverre ikke fokus i denne PR.