### PR TITLE
Ensure that travis doesn't self-update composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - 10
 
 before_script:
+  - composer self-update --rollback
   - composer install
 
 script:


### PR DESCRIPTION
Composer versjon 2 er kommet, men vi kjører ikke dette i prod. Denne PRen påser at travis samsvarer med prod.