### PR TITLE
Remove deprecated method loadClassCache

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -5,7 +5,6 @@ use Symfony\Component\HttpFoundation\Request;
 require __DIR__.'/../vendor/autoload.php';
 
 $kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
 
 // If you use HTTP Cache and your application relies on the _method request parameter
 // to get the intended HTTP method, uncomment this line.

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -21,9 +21,6 @@ require __DIR__.'/../vendor/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-if (PHP_VERSION_ID < 70000) {
-	$kernel->loadClassCache();
-}
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/web/app_staging.php
+++ b/web/app_staging.php
@@ -17,7 +17,6 @@ if ( isset( $_SERVER['HTTP_CLIENT_IP'] )
 require __DIR__ . '/../vendor/autoload.php';
 
 $kernel = new AppKernel( 'staging', false );
-$kernel->loadClassCache();
 
 // If you use HTTP Cache and your application relies on the _method request parameter
 // to get the intended HTTP method, uncomment this line.


### PR DESCRIPTION
Metoden `loadClassCache` er deprecated og fjernes i Symfony 4.0. 
Se [`https://symfony.com/blog/new-in-symfony-3-3-deprecated-the-classloader-component`](https://symfony.com/blog/new-in-symfony-3-3-deprecated-the-classloader-component)

Metoden ble brukt for php versjoner lavere enn 7, og har derfor ikke noe nytte for oss (og derfor deprecated).
