### PR TITLE
Deprecations

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -71,7 +71,6 @@ framework:
         #assets_version: SomeVersionScheme
     default_locale:  "%locale%"
     trusted_hosts:   ~
-    trusted_proxies: ~
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,6 +17,8 @@ parameters:
     refresh_token: '%google_api_refresh_token%'
     disabled: true
 
+  container.dumper.inline_class_loader: true
+
   slack.notification_channel: '#notifications'
   slack.log_channel: '%log_channel%'
   slack.disable_delivery: '%slack_disabled%'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -2,6 +2,7 @@ services:
     _defaults:
         autowire: true
         autoconfigure: true
+        public: true
         bind:
             AppBundle\Mailer\MailerInterface: '@AppBundle\Mailer\Mailer'
             AppBundle\Sms\SmsSenderInterface: '@AppBundle\Sms\SmsSender'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -26,6 +26,9 @@ services:
         arguments:
             - { timeout: 2 }
 
+    AppBundle\Sms\SlackSms:
+        autowire: true
+
     AppBundle\Sms\SmsSender:
         arguments:
             $env: '%kernel.environment%'

--- a/src/AppBundle/Controller/ArticleAdminController.php
+++ b/src/AppBundle/Controller/ArticleAdminController.php
@@ -131,7 +131,7 @@ class ArticleAdminController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $em      = $this->getDoctrine()->getManager();
+            $em = $this->getDoctrine()->getManager();
 
             $imageSmall = $this->get(FileUploader::class)->uploadArticleImage($request, 'imgsmall');
             if ($imageSmall) {


### PR DESCRIPTION
This PR fixes some more deprecations.

- It declares all services to be public in `services.yml`.
This sorts out the two following deprecations:
<img src="https://user-images.githubusercontent.com/46197518/99915928-285aea80-2d07-11eb-88d7-2e3d3ef6e7e2.png" width=650>

-- 
- PR adds `SlackSms` as a service in `services.yml`, and enables auto-wiring for it. This solves this deprecation:
![image](https://user-images.githubusercontent.com/46197518/99917342-e97d6280-2d0f-11eb-874e-237179cc4d43.png)


--
- PR also sets `container.dumper.inline_class_loader: true` in `config.yml`.
<img src="https://user-images.githubusercontent.com/46197518/99916052-fbf39e00-2d07-11eb-8612-886d14ff184a.png" width=650>

--
- PR removes `trusted_proxies` from `config.yml`, which fixes this deprecation:
<img src="https://user-images.githubusercontent.com/46197518/99997778-ef318180-2dbd-11eb-9d54-7000dbfbbdf5.png" width=750>


-----
Closes #1400,  #1403 


