### PR TITLE
Change wording in refund form

### DIFF
--- a/app/Resources/views/receipt/create_receipt.html.twig
+++ b/app/Resources/views/receipt/create_receipt.html.twig
@@ -5,7 +5,7 @@
             {{ form_row(form.sum) }}
             <p class="mt-0 mb-3">
                 <span class="font-weight-bold">Merk:</span>
-                Summen må stemme nøyaktig med den på kvitteringen hvis hele beløpet skal dekkes. Hvis ikke, skriv beløpet som skal dekkes.
+                Summen må stemme nøyaktig med den på kvitteringen hvis hele beløpet skal dekkes. Hvis du kun får dekket deler av summen, skriv beløpet som skal dekkes.
             </p>
             {{ form_row(form.receiptDate) }}
             {% include 'receipt/account_number.html.twig' %}

--- a/src/AppBundle/Form/Type/ReceiptType.php
+++ b/src/AppBundle/Form/Type/ReceiptType.php
@@ -23,7 +23,7 @@ class ReceiptType extends AbstractType
                 'attr' => array('rows' => 3, 'placeholder' => 'Hva har du lagt ut penger for?'),
             ))
             ->add('sum', MoneyType::class, array(
-                'label' => 'Sum',
+                'label' => 'Sum du ønsker tilbakebetalt',
                 'required' => true,
                 'currency' => null,
                 'attr' => array('pattern' => '\d*[.,]?\d+$'),


### PR DESCRIPTION
We have received complaints regarding the refund form. This suggested change in wording is meant to make the form clearer.
